### PR TITLE
fix(types): seven correctness fixes plus strict-default flip

### DIFF
--- a/packages/http/http.rip
+++ b/packages/http/http.rip
@@ -10,6 +10,76 @@
 # instances with prefixUrl and default headers — all in pure Rip, zero deps.
 # ==============================================================================
 
+# ==[ Public API types ]==
+#
+# These types describe the consumer-facing contract — what to pass to
+# `http.create({...})`, what hooks receive, what fields HTTPError carries.
+# Internal helpers and locals rely on inference; the type system here
+# documents how to USE this package, not how it's implemented.
+
+export type RetryConfig =
+  limit?: number
+  methods?: string[]
+  statusCodes?: number[]
+  backoffLimit?: number
+  delay?: (attempt: number) => number
+
+export type RetryOption = number | RetryConfig | false
+
+export type BeforeRetryInfo =
+  request: Request
+  options: HttpOptions
+  error: Error | null
+  retryCount: number
+
+export type BeforeRequestHook = (request: Request, options: HttpOptions) => Request | Response | void | Promise<Request | Response | void>
+export type AfterResponseHook = (request: Request, options: HttpOptions, response: Response) => Response | void | Promise<Response | void>
+export type BeforeRetryHook   = (info: BeforeRetryInfo) => void | Promise<void>
+export type BeforeErrorHook   = (error: HTTPError) => HTTPError | Promise<HTTPError>
+
+export type Hooks =
+  beforeRequest?: BeforeRequestHook[]
+  afterResponse?: AfterResponseHook[]
+  beforeRetry?: BeforeRetryHook[]
+  beforeError?: BeforeErrorHook[]
+
+export type HttpOptions =
+  method?: string
+  json?: unknown
+  body?: BodyInit | null
+  headers?: HeadersInit
+  prefixUrl?: string
+  searchParams?: URLSearchParams | string | Record<string, unknown>
+  timeout?: number | false
+  retry?: RetryOption
+  throwHttpErrors?: boolean
+  hooks?: Hooks
+  mode?: RequestMode
+  credentials?: RequestCredentials
+  cache?: RequestCache
+  redirect?: RequestRedirect
+  referrer?: string
+  referrerPolicy?: ReferrerPolicy
+  integrity?: string
+  keepalive?: boolean
+  signal?: AbortSignal | null
+
+type CallFn = (input: string | URL, opts?: HttpOptions) => Promise<Response>
+
+type HttpInstanceMembers =
+  get: CallFn
+  post: CallFn
+  put: CallFn
+  patch: CallFn
+  del: CallFn
+  head: CallFn
+  create: (opts?: HttpOptions) => HttpInstance
+  extend: (opts?: HttpOptions) => HttpInstance
+  HTTPError: typeof HTTPError
+  TimeoutError: typeof TimeoutError
+
+export type HttpInstance = CallFn & HttpInstanceMembers
+
 # ==[ Defaults ]==
 
 RETRY_METHODS =! ['GET', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'TRACE']
@@ -20,25 +90,37 @@ TIMEOUT_MS    =! 10000
 
 # ==[ Error Classes ]==
 
-class HTTPError extends Error
-  constructor: (@response, @request, @options) ->
-    super("Request failed with status #{@response.status}")
-    @name = 'HTTPError'
+export class HTTPError extends Error
+  constructor: (response, request, options) ->
+    super("Request failed with status #{response.status}")
+    @response = response
+    @request  = request
+    @options  = options
+    @name     = 'HTTPError'
 
-class TimeoutError extends Error
-  constructor: (@request) ->
+export interface HTTPError
+  response: Response
+  request: Request
+  options: HttpOptions
+
+export class TimeoutError extends Error
+  constructor: (request) ->
     super('Request timed out')
-    @name = 'TimeoutError'
+    @request = request
+    @name    = 'TimeoutError'
+
+export interface TimeoutError
+  request: Request
 
 # ==[ Helpers ]==
 
-def buildUrl(input, opts)
+def buildUrl(input, opts:: HttpOptions = {})
   base = opts.prefixUrl
   if base
     unless base.endsWith('/')
       base += '/'
-    input = input.slice(1) if typeof input is 'string' and input.startsWith('/')
-    url = new URL(input, base)
+    path = if typeof input is 'string' and input.startsWith('/') then input.slice(1) else input
+    url = new URL(path, base)
   else
     url = new URL(input)
 
@@ -54,20 +136,21 @@ def buildUrl(input, opts)
 
   url
 
-def mergeHeaders(a, b)
+def mergeHeaders(a?:: HeadersInit, b?:: HeadersInit)
   result = new Headers(a ?? {})
   if b
     h = new Headers(b)
     h.forEach (v, k) -> result.set(k, v)
   result
 
-def mergeHooks(a = {}, b = {})
-  merged = {}
-  for key in ['beforeRequest', 'beforeRetry', 'afterResponse', 'beforeError']
-    merged[key] = [...(a[key] ?? []), ...(b[key] ?? [])]
-  merged
+def mergeHooks(a:: Hooks = {}, b:: Hooks = {})
+  return
+    beforeRequest: [...(a.beforeRequest ?? []), ...(b.beforeRequest ?? [])]
+    afterResponse: [...(a.afterResponse ?? []), ...(b.afterResponse ?? [])]
+    beforeRetry:   [...(a.beforeRetry   ?? []), ...(b.beforeRetry   ?? [])]
+    beforeError:   [...(a.beforeError   ?? []), ...(b.beforeError   ?? [])]
 
-def mergeOptions(defaults, overrides)
+def mergeOptions(defaults:: HttpOptions = {}, overrides:: HttpOptions = {})
   opts = { ...defaults, ...overrides }
   if defaults.headers or overrides.headers
     opts.headers = mergeHeaders(defaults.headers, overrides.headers)
@@ -76,9 +159,9 @@ def mergeOptions(defaults, overrides)
   opts
 
 def normalizeRetry(retry)
-  return { limit: 0 } if retry is false
+  return { limit: 0, methods: [], statusCodes: [], backoffLimit: Infinity, delay: null } if retry is false
   if typeof retry is 'number'
-    { limit: retry, methods: RETRY_METHODS, statusCodes: RETRY_CODES, backoffLimit: Infinity }
+    { limit: retry, methods: RETRY_METHODS, statusCodes: RETRY_CODES, backoffLimit: Infinity, delay: null }
   else if typeof retry is 'object'
     limit:        retry.limit        ?? RETRY_LIMIT
     methods:      retry.methods      ?? RETRY_METHODS
@@ -86,7 +169,7 @@ def normalizeRetry(retry)
     backoffLimit: retry.backoffLimit ?? Infinity
     delay:        retry.delay        ?? null
   else
-    { limit: RETRY_LIMIT, methods: RETRY_METHODS, statusCodes: RETRY_CODES, backoffLimit: Infinity }
+    { limit: RETRY_LIMIT, methods: RETRY_METHODS, statusCodes: RETRY_CODES, backoffLimit: Infinity, delay: null }
 
 def delay(ms)
   new Promise (resolve) -> setTimeout(resolve, ms)
@@ -103,7 +186,7 @@ def retryDelay(attempt, res, cfg)
   if header
     secs = Number(header)
     if Number.isNaN(secs)
-      Math.max(0, new Date(header) - Date.now())
+      Math.max(0, new Date(header).getTime() - Date.now())
     else
       secs * 1000
   else
@@ -111,35 +194,50 @@ def retryDelay(attempt, res, cfg)
 
 # ==[ Core Request ]==
 
-def request(input, opts = {})
+def request(input, opts:: HttpOptions = {})
   method          = (opts.method ?? 'GET').toUpperCase()
   timeout         = opts.timeout ?? TIMEOUT_MS
   throwHttpErrors = opts.throwHttpErrors ?? true
   retry           = normalizeRetry(opts.retry)
   hooks           = opts.hooks ?? {}
 
-  # Build URL
-  url = buildUrl(input, opts)
-
-  # Build headers
+  url     = buildUrl(input, opts)
   headers = mergeHeaders(opts.headers)
 
-  # JSON body convenience
+  # JSON body convenience. `json: null` is intentionally distinct from
+  # an absent `json` key — the former should send the literal body
+  # `"null"` with a JSON content-type, the latter should send no JSON
+  # body at all. `opts.json?` would conflate them (treats null as
+  # absent), so test for explicit presence instead.
   body = opts.body
-  if opts.json?
+  if 'json' of opts and opts.json isnt undefined
     body = JSON.stringify(opts.json)
     headers.set('content-type', 'application/json') unless headers.has('content-type')
 
-  # Assemble fetch options, passing through native fetch fields
-  fetchOpts = { method, headers, body }
-  for key in ['mode', 'credentials', 'cache', 'redirect', 'referrer', 'referrerPolicy', 'integrity', 'keepalive', 'signal']
-    fetchOpts[key] = opts[key] if opts[key]?
+  # Compose the fetch signal so caller aborts and our timeout are both
+  # honored. Computed in one shot so TS infers a sensible union type
+  # without needing typed-local annotations.
+  fetchSignal = if opts.signal and timeout and timeout isnt Infinity
+    AbortSignal.any [opts.signal, AbortSignal.timeout(timeout)]
+  else if timeout and timeout isnt Infinity
+    AbortSignal.timeout(timeout)
+  else
+    opts.signal ?? null
 
-  # Timeout via AbortSignal (unless caller provided their own signal)
-  if timeout and timeout isnt Infinity and not fetchOpts.signal
-    fetchOpts.signal = AbortSignal.timeout(timeout)
+  fetchOpts =
+    method:         method
+    headers:        headers
+    body:           body
+    mode:           opts.mode
+    credentials:    opts.credentials
+    cache:          opts.cache
+    redirect:       opts.redirect
+    referrer:       opts.referrer
+    referrerPolicy: opts.referrerPolicy
+    integrity:      opts.integrity
+    keepalive:      opts.keepalive
+    signal:         fetchSignal
 
-  # Build Request
   req = new Request(url, fetchOpts)
 
   # Run beforeRequest hooks — may modify the request or short-circuit with a Response
@@ -154,12 +252,18 @@ def request(input, opts = {})
   # Retry loop
   retryCount = 0
   loop
-    res = null
+    res:: Response | null = null
 
     try
       res = fetch!(req.clone())
     catch err
-      if err.name is 'AbortError' or err.name is 'TimeoutError'
+      # Distinguish a caller-driven cancellation from our timeout.
+      # If `opts.signal` aborted, rethrow the original AbortError so
+      # the caller's cancellation semantics are preserved. Otherwise
+      # an AbortError/TimeoutError means our timeout fired — surface
+      # it as a TimeoutError.
+      if err?.name is 'AbortError' or err?.name is 'TimeoutError'
+        throw err if opts.signal?.aborted
         throw new TimeoutError(req)
 
       # Network error — retry if eligible
@@ -185,6 +289,9 @@ def request(input, opts = {})
       if hooks.beforeRetry?.length
         for hook in hooks.beforeRetry
           hook!({ request: req, options: opts, error: null, retryCount })
+      # Free the failed response's body before retrying so the
+      # underlying connection can be reused / released.
+      try res.body?.cancel()
       delay!(retryDelay(retryCount, res, retry))
       continue
 
@@ -199,24 +306,29 @@ def request(input, opts = {})
     return res
 
 # ==[ Instance Factory ]==
+#
+# `Object.assign(call, members)` is the idiomatic TypeScript pattern for
+# building a callable-with-properties (function plus methods/fields). The
+# `:: HttpInstance` return type on `makeInstance` is the one annotation
+# that earns its keep here — it lets TypeScript validate the assembled
+# shape against the public `HttpInstance` contract.
 
-def makeInstance(defaults = {})
-  inst = (input, opts = {}) -> request(input, mergeOptions(defaults, opts))
+def buildMethod(call, method)
+  (input, opts = {}) -> call(input, { ...opts, method })
 
-  inst.get   = (input, opts = {}) -> inst(input, { ...opts, method: 'GET' })
-  inst.post  = (input, opts = {}) -> inst(input, { ...opts, method: 'POST' })
-  inst.put   = (input, opts = {}) -> inst(input, { ...opts, method: 'PUT' })
-  inst.patch = (input, opts = {}) -> inst(input, { ...opts, method: 'PATCH' })
-  inst.del   = (input, opts = {}) -> inst(input, { ...opts, method: 'DELETE' })
-  inst.head  = (input, opts = {}) -> inst(input, { ...opts, method: 'HEAD' })
-
-  inst.create = (opts = {}) -> makeInstance(opts)
-  inst.extend = (opts = {}) -> makeInstance(mergeOptions(defaults, opts))
-
-  inst.HTTPError    = HTTPError
-  inst.TimeoutError = TimeoutError
-
-  inst
+def makeInstance(defaults:: HttpOptions = {}):: HttpInstance
+  call = (input, opts = {}) -> request(input, mergeOptions(defaults, opts))
+  Object.assign call,
+    get:          buildMethod(call, 'GET')
+    post:         buildMethod(call, 'POST')
+    put:          buildMethod(call, 'PUT')
+    patch:        buildMethod(call, 'PATCH')
+    del:          buildMethod(call, 'DELETE')
+    head:         buildMethod(call, 'HEAD')
+    create:       (opts = {}) -> makeInstance(opts)
+    extend:       (opts = {}) -> makeInstance(mergeOptions(defaults, opts))
+    HTTPError:    HTTPError
+    TimeoutError: TimeoutError
 
 # ==[ Public API ]==
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -628,7 +628,12 @@ export class CodeEmitter {
       if (Array.isArray(head)) { sexpr.forEach(item => collect(item)); return; }
       if (CodeEmitter.ASSIGNMENT_OPS.has(head)) {
         let [target, value] = rest;
-        if (typeof target === 'string') vars.add(target);
+        // Match collectProgramVariables: identifier targets may arrive as
+        // String wrappers when types.js attaches `.data.type` metadata
+        // to a typed local. Without unwrapping the wrapper, typed locals
+        // skip the function-top `let` declaration and silently leak to
+        // the global scope.
+        if (typeof target === 'string' || target instanceof String) vars.add(str(target));
         else if (this.is(target, 'array')) this.collectVarsFromArray(target, vars);
         else if (this.is(target, 'object')) this.collectVarsFromObject(target, vars);
         collect(value);
@@ -2515,14 +2520,18 @@ export class CodeEmitter {
           let atParamMap = isSubclass ? new Map() : null;
           cleanParams = params.map(p => {
             if (this.is(p, '.') && p[1] === 'this') {
-              let name = p[2];
+              // Unwrap String-wrapper identifiers — typed @field params
+              // arrive with their type metadata attached as `.data.type`
+              // and would otherwise miss the atParamMap key match (the
+              // map is queried with primitive strings via `str(prop)`).
+              let name = str(p[2]);
               let param = isSubclass ? `_${name}` : name;
               autoAssign.push(`this.${name} = ${param}`);
               if (isSubclass) atParamMap.set(name, param);
               return param;
             }
             if (this.is(p, 'default') && this.is(p[1], '.') && p[1][1] === 'this') {
-              let name = p[1][2];
+              let name = str(p[1][2]);
               let param = isSubclass ? `_${name}` : name;
               autoAssign.push(`this.${name} = ${param}`);
               if (isSubclass) atParamMap.set(name, param);

--- a/src/dts.js
+++ b/src/dts.js
@@ -78,6 +78,7 @@ export function emitTypes(tokens, sexpr = null, source = '') {
   let indentStr = '  ';
   let indent = () => indentStr.repeat(indentLevel);
   let inClass = false;
+  let inSubclass = false; // Tracks whether the active class extends another
   let classFields = new Set(); // Track emitted field names to avoid duplicates
   let usesSignal = false;
   let usesComputed = false;
@@ -272,7 +273,13 @@ export function emitTypes(tokens, sexpr = null, source = '') {
   };
 
   // Collect function parameters (handles simple, destructured, rest, defaults)
-  let collectParams = (tokens, startIdx) => {
+  //
+  // `subclassConstructor` mirrors the compiler's @-shorthand renaming:
+  // when a constructor lives inside `class Foo extends Bar`, the compiler
+  // rewrites `@name` params to `_name` so the assignment `this.name =
+  // _name` can run AFTER `super(...)`. The shadow TS must use the same
+  // `_name` binding or the body's `_name` references will be unresolved.
+  let collectParams = (tokens, startIdx, subclassConstructor = false) => {
     let params = [];
     let fields = []; // Track @param:: type for class field emission
     let j = startIdx;
@@ -300,7 +307,8 @@ export function emitTypes(tokens, sexpr = null, source = '') {
         if (tokens[j]?.[0] === 'PROPERTY' || tokens[j]?.[0] === 'IDENTIFIER') {
           let name = tokens[j][1];
           let type = tokens[j].data?.type;
-          params.push(type ? `${name}: ${expandSuffixes(type)}` : name);
+          let paramName = subclassConstructor ? `_${name}` : name;
+          params.push(type ? `${paramName}: ${expandSuffixes(type)}` : paramName);
           if (type) fields.push({ name, type: expandSuffixes(type) });
           j++;
         }
@@ -364,7 +372,11 @@ export function emitTypes(tokens, sexpr = null, source = '') {
         }
         j++;
 
-        // Skip past default value expression
+        // Skip past default value expression. Stops at the next top-level
+        // comma, the matching CALL_END, or the matching PARAM_END — the
+        // last is critical for arrow-function param lists wrapped in
+        // PARAM_START/PARAM_END (e.g. `(input, opts = {}) -> ...`),
+        // because PARAM_END is the only sentinel that closes the list.
         if (hasDefault) {
           j++; // skip =
           let dd = 0;
@@ -372,7 +384,7 @@ export function emitTypes(tokens, sexpr = null, source = '') {
             let dt = tokens[j];
             if (dt[0] === '(' || dt[0] === '[' || dt[0] === '{') dd++;
             if (dt[0] === ')' || dt[0] === ']' || dt[0] === '}') dd--;
-            if (dd === 0 && (dt[1] === ',' || dt[0] === 'CALL_END')) break;
+            if (dd === 0 && (dt[1] === ',' || dt[0] === 'CALL_END' || dt[0] === 'PARAM_END')) break;
             j++;
           }
         }
@@ -386,6 +398,15 @@ export function emitTypes(tokens, sexpr = null, source = '') {
   };
 
   let paramDepth = 0;
+  // bodyDepth counts how deep we are inside `def`/`->` bodies. At
+  // bodyDepth === 0 we're at module scope and dts.js may emit
+  // `declare function NAME(...)` for arrow assignments. Inside a
+  // function body, those assignments would be locals (e.g.
+  // `inst = (input, opts) -> ...` inside `def makeInstance`) and
+  // emitting a module-scope declare for them is wrong — TypeScript
+  // would treat the local and the (synthetic) global as separate
+  // bindings, causing the local to lose its type info.
+  let bodyDepth = 0;
   for (let i = 0; i < tokens.length; i++) {
     let t = tokens[i];
     let tag = t[0];
@@ -405,18 +426,17 @@ export function emitTypes(tokens, sexpr = null, source = '') {
       t = tokens[i];
       tag = t[0];
 
-      // Export default
+      // Export default — runtime statement, not a type declaration.
+      // The compiled JS body already carries `export default x`; emitting
+      // a duplicate here puts two `export default` declarations in front
+      // of the TypeScript language service and triggers TS2528. Skip the
+      // entire `export default ...` clause and let the body provide it.
       if (tag === 'DEFAULT') {
         i++;
-        if (i >= tokens.length) break;
-        t = tokens[i];
-        tag = t[0];
-
-        // export default IDENTIFIER (re-export)
-        if (tag === 'IDENTIFIER') {
-          lines.push(`${indent()}export default ${t[1]};`);
+        if (i < tokens.length) {
+          t = tokens[i];
+          tag = t[0];
         }
-        // export default { ... } or other expressions — skip for now
         continue;
       }
     }
@@ -538,9 +558,11 @@ export function emitTypes(tokens, sexpr = null, source = '') {
 
       // Check for extends
       let ext = '';
+      let isSubclass = false;
       let j = i + 2;
       if (tokens[j]?.[0] === 'EXTENDS') {
         ext = ` extends ${tokens[j + 1]?.[1] || ''}`;
+        isSubclass = true;
         j += 2;
       }
 
@@ -558,6 +580,7 @@ export function emitTypes(tokens, sexpr = null, source = '') {
         if (hasTypedMembers) {
           lines.push(`${indent()}${exp}declare class ${className}${ext} {`);
           inClass = true;
+          inSubclass = isSubclass;
           classFields.clear();
           indentLevel++;
         }
@@ -617,7 +640,12 @@ export function emitTypes(tokens, sexpr = null, source = '') {
           let params = [];
           let fields = [];
           if (tokens[j]?.[0] === 'PARAM_START') {
-            let result = collectParams(tokens, j);
+            // The compiler renames `@name` → `_name` on subclass
+            // constructors so `this.name = _name` runs after super();
+            // mirror that here so the shadow TS body's `_name`
+            // references resolve to a real param binding.
+            let isSubCtor = inSubclass && methodName === 'constructor';
+            let result = collectParams(tokens, j, isSubCtor);
             params = result.params;
             fields = result.fields;
             j = result.endIdx + 1;
@@ -661,19 +689,36 @@ export function emitTypes(tokens, sexpr = null, source = '') {
 
     // Track INDENT/OUTDENT for class body
     if (tag === 'INDENT') {
+      bodyDepth++;
       continue;
     }
     if (tag === 'OUTDENT') {
+      if (bodyDepth > 0) bodyDepth--;
       if (inClass) {
         indentLevel--;
         lines.push(`${indent()}}`);
         inClass = false;
+        inSubclass = false;
       }
       continue;
     }
 
     // Arrow function assignment: name = (params) -> body
-    if (tag === 'IDENTIFIER' && !inClass && tokens[i + 1]?.[0] === '=' &&
+    //
+    // Emission shape depends on scope:
+    //   bodyDepth === 0  → `declare function name(...): R;` at module
+    //                       scope. typecheck.js attaches this as an
+    //                       overload and copies typed params into the
+    //                       impl line.
+    //   bodyDepth >  0   → `let name: (params) => R;` at module scope.
+    //                       typecheck.js's typed-local hoist pulls the
+    //                       `: (...) => R` into the body's `let name`,
+    //                       making the arrow contextually typed.
+    //
+    // The function-form is wrong inside bodies because it would create
+    // a phantom global that shadows / collides with the actual local.
+    if (tag === 'IDENTIFIER' && !inClass &&
+        tokens[i + 1]?.[0] === '=' &&
         (tokens[i + 2]?.[0] === 'PARAM_START' || tokens[i + 2]?.[0] === '(')) {
       let fnName = t[1];
       let j = i + 2;
@@ -693,10 +738,22 @@ export function emitTypes(tokens, sexpr = null, source = '') {
 
       if (returnType || params.some(p => p.includes(':'))) {
         let exp = exported ? 'export ' : '';
-        let declare = exported ? '' : 'declare ';
-        let ret = returnType ? `: ${expandSuffixes(returnType)}` : '';
         let paramStr = params.join(', ');
-        lines.push(`${indent()}${exp}${declare}function ${fnName}(${paramStr})${ret};`);
+        if (bodyDepth === 0) {
+          let declare = exported ? '' : 'declare ';
+          let ret = returnType ? `: ${expandSuffixes(returnType)}` : '';
+          lines.push(`${indent()}${exp}${declare}function ${fnName}(${paramStr})${ret};`);
+        } else {
+          // `any` rather than `unknown` for the inferred-return case.
+          // The annotation's job is to give the body's `let X` a typed
+          // function shape so call-site param checks engage; we
+          // intentionally don't constrain the return type when the
+          // user didn't provide one. `unknown` would force callers to
+          // narrow before using the result, creating new false
+          // positives at every call site.
+          let ret = returnType ? expandSuffixes(returnType) : 'any';
+          lines.push(`${indent()}let ${fnName}: (${paramStr}) => ${ret};`);
+        }
         continue;
       }
     }

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1483,6 +1483,29 @@ export class Lexer {
       this.inTypeAnnotation = false;
     }
 
+    // Enter type-alias body context: `type IDENTIFIER =` is followed by a
+    // type expression where reserved-word type tokens like `void` should be
+    // accepted. Without this, `type Foo = T | void` and `Promise<void>` in
+    // the body trip the reserved-word check at identifier time. The `=`
+    // reset above runs first; here we re-enable inTypeAnnotation when the
+    // statement-start lookback sees `type IDENTIFIER`. (`interface` bodies
+    // already work because they use `name:: T` per-property, which sets
+    // inTypeAnnotation via `::`.)
+    if (val === '=') {
+      let n = this.tokens.length;
+      let isTypeAlias =
+        n >= 2 &&
+        this.tokens[n - 1][0] === 'IDENTIFIER' &&
+        this.tokens[n - 2][0] === 'IDENTIFIER' &&
+        this.tokens[n - 2][1] === 'type' &&
+        (n === 2 ||
+          this.tokens[n - 3][0] === 'TERMINATOR' ||
+          this.tokens[n - 3][0] === 'INDENT' ||
+          this.tokens[n - 3][0] === 'OUTDENT' ||
+          this.tokens[n - 3][0] === 'EXPORT');
+      if (isTypeAlias) this.inTypeAnnotation = true;
+    }
+
     // Balanced pair tracking
     if (val === '(' || val === '{' || val === '[') {
       this.ends.push({tag: INVERSES[val], origin: [tag, val]});

--- a/src/typecheck.js
+++ b/src/typecheck.js
@@ -606,14 +606,22 @@ export function cleanDiagnosticMessage(msg) {
 }
 
 // Base TypeScript compiler settings for type-checking. Callers can
-// pass overrides (e.g. { noImplicitAny: true } for the CLI).
+// pass overrides (e.g. { strict: true } when a project opts in).
+//
+// Default `strict: false` aligns with Rip's stated philosophy
+// ("optional, design scaffolding, not safety rails") and matches the
+// gradual-typing default of comparable systems (Sorbet's `# typed: false`,
+// mypy's permissive default, Hack's `partial`, TypeScript's own pre-strict
+// default). Projects opt UP to strict via rip.json's `strict: true`.
 export function createTypeCheckSettings(ts, overrides = {}) {
   return {
     target: ts.ScriptTarget.ESNext,
     module: ts.ModuleKind.ESNext,
     moduleResolution: ts.ModuleResolutionKind.Bundler,
     allowJs: true,
-    strict: true,
+    strict: false,
+    noImplicitAny: false,
+    strictNullChecks: false,
     noEmit: true,
     skipLibCheck: true,
     ...overrides,
@@ -647,6 +655,150 @@ function replaceFnParams(line, newParams) {
     i++;
   }
   return depth === 0 ? line.slice(0, idx + 1) + newParams + line.slice(i - 1) : line;
+}
+
+// Depth-aware split of a parameter list on top-level commas. Respects
+// nested parens, brackets, braces, and angle brackets so callback types
+// like `(fn: (x: number) => void)` and generic types like `Map<K, V>`
+// don't get split mid-argument.
+//
+// Angle brackets are tracked separately because `>` is ambiguous: it
+// appears in `=>` (function-type arrow), `>=`/`>>`/`>=`, and as a
+// generic-close. We only treat `<` as opening a generic when it
+// follows an identifier-ending character (or another `<` for nested
+// `Map<K, Set<V>>`); arrow `=>` is recognized and skipped before any
+// angle handling. String/template/regex literals are skipped wholesale
+// so commas inside them don't terminate a part.
+function splitTopLevelParams(paramsStr) {
+  const parts = [];
+  let depth = 0;     // counts (), [], {}
+  let angle = 0;     // counts <> when used as generics
+  let start = 0;
+  const isWordEnd = (i) => i > 0 && /[A-Za-z_$0-9>\]]/.test(paramsStr[i - 1]);
+  const skipString = (i, quote) => {
+    let k = i + 1;
+    while (k < paramsStr.length && paramsStr[k] !== quote) {
+      if (paramsStr[k] === '\\') k += 2; else k++;
+    }
+    return k;
+  };
+  for (let i = 0; i < paramsStr.length; i++) {
+    const c = paramsStr[i];
+    // Skip strings to avoid commas / brackets inside string defaults.
+    if (c === '"' || c === "'" || c === '`') {
+      i = skipString(i, c);
+      continue;
+    }
+    if (c === '(' || c === '[' || c === '{') { depth++; continue; }
+    if (c === ')' || c === ']' || c === '}') { depth--; continue; }
+    // Arrow `=>` — ignore the `>` so it doesn't decrement angle/depth.
+    if (c === '=' && paramsStr[i + 1] === '>') { i++; continue; }
+    if (c === '<' && isWordEnd(i)) { angle++; continue; }
+    if (c === '>' && angle > 0) { angle--; continue; }
+    if (c === ',' && depth === 0 && angle === 0) {
+      parts.push(paramsStr.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  const last = paramsStr.slice(start).trim();
+  if (last.length > 0) parts.push(last);
+  return parts;
+}
+
+// Find the top-level `= default` separator in a single parameter slot,
+// skipping `=` inside destructured patterns (`{a = 1, b = 2}`) and inside
+// type expressions. Returns the index of the `=` or -1 if none.
+//
+// A param shape is one of:
+//   simple        — `name`, `name: T`, `name?: T`
+//   rest          — `...rest`, `...rest: T[]`
+//   destructured  — `{a, b}`, `{a, b}: {a: T, b: U}`, `[x, y]: [T, U]`
+//
+// The default arrives at the OUTERMOST level only, after the optional
+// type annotation. Inside the destructured pattern's braces/brackets,
+// `=` denotes per-property defaults (a JS pattern feature) and is not
+// the slot's outer default — those belong to the destructured shape and
+// don't survive the merge. Only the top-level `=` matters.
+//
+// Skips strings/templates and uses the same identifier-aware angle
+// tracking as `splitTopLevelParams` so default expressions containing
+// `=>`, `<`, `>`, comparisons, or generic types don't confuse depth.
+function findOuterDefault(paramPart) {
+  let depth = 0;
+  let angle = 0;
+  const isWordEnd = (i) => i > 0 && /[A-Za-z_$0-9>\]]/.test(paramPart[i - 1]);
+  const skipString = (i, quote) => {
+    let k = i + 1;
+    while (k < paramPart.length && paramPart[k] !== quote) {
+      if (paramPart[k] === '\\') k += 2; else k++;
+    }
+    return k;
+  };
+  for (let i = 0; i < paramPart.length; i++) {
+    const c = paramPart[i];
+    if (c === '"' || c === "'" || c === '`') { i = skipString(i, c); continue; }
+    if (c === '(' || c === '[' || c === '{') { depth++; continue; }
+    if (c === ')' || c === ']' || c === '}') { depth--; continue; }
+    if (c === '<' && isWordEnd(i)) { angle++; continue; }
+    if (c === '>' && angle > 0) { angle--; continue; }
+    if (c === '=' && depth === 0 && angle === 0) {
+      // `==`, `===`, `!=`, `!==`, `>=`, `<=`, `=>` are operators, not
+      // the default `=` separator.
+      const prev = paramPart[i - 1];
+      const next = paramPart[i + 1];
+      if (next === '=' || next === '>') { i++; continue; }
+      if (prev === '=' || prev === '!' || prev === '<' || prev === '>') continue;
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Merge a DTS-emitted sig's params into the impl line's params, preserving
+// the impl's default values. The DTS emits `name?: T` for parameters with
+// JS defaults (because callers may omit them — that's the overload view),
+// but inside the body the default ensures `name` is always defined, so the
+// body should see `name: T = default`, not `name?: T`. This merge keeps the
+// caller-facing overload `name?: T` and produces a body-facing impl where
+// each defaulted slot becomes `name: T = default`. Non-defaulted impl
+// params keep whatever the sig provided (`name?: T` for `?:: T` params,
+// `name: T` for required typed params, bare `name` for untyped).
+//
+// Returns the merged param string, or `sigParams` unchanged if the impl
+// has no top-level defaults to preserve.
+function mergeSigWithImplDefaults(sigParams, implParams) {
+  if (!implParams) return sigParams;
+  const sigList = splitTopLevelParams(sigParams);
+  const implList = splitTopLevelParams(implParams);
+  if (sigList.length !== implList.length) return sigParams; // shape mismatch — bail
+  let anyDefault = false;
+  for (const p of implList) { if (findOuterDefault(p) >= 0) { anyDefault = true; break; } }
+  if (!anyDefault) return sigParams;
+  const merged = [];
+  for (let i = 0; i < sigList.length; i++) {
+    const sigPart = sigList[i];
+    const implPart = implList[i];
+    const eqIdx = findOuterDefault(implPart);
+    if (eqIdx < 0) {
+      // No top-level default in impl — use the sig form unchanged.
+      merged.push(sigPart);
+      continue;
+    }
+    const defaultExpr = implPart.slice(eqIdx + 1).trim();
+    // Drop `?` from the sig param's name binding and append `= default`.
+    // Pattern: NAME, NAME?: T, NAME: T, ...REST: T[], {a, b}: {...}, [x, y]: [...]
+    const colonMatch = sigPart.match(/^(\s*(?:\.\.\.|))([A-Za-z_$][\w$]*|\{[\s\S]*?\}|\[[\s\S]*?\])(\?)?(\s*:\s*[\s\S]+)?$/);
+    if (!colonMatch) {
+      // Couldn't parse — keep sig form, append default conservatively.
+      merged.push(`${sigPart} = ${defaultExpr}`);
+      continue;
+    }
+    const prefix = colonMatch[1] || '';
+    const name   = colonMatch[2];
+    const tail   = colonMatch[4] || '';
+    merged.push(`${prefix}${name}${tail} = ${defaultExpr}`);
+  }
+  return merged.join(', ');
 }
 
 // Extract the type parameter list (e.g. "<K extends string>") between the
@@ -713,6 +865,125 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
   if (hasTypes && dts && code) {
     const dl = dts.split('\n');
     const cl = code.split('\n');
+
+    // Hoist locally-scoped typed declarations into the function body's
+    // hoisted `let` line. dts.js emits `let name: T;` at the DTS header
+    // for any typed assignment, including locals declared inside function
+    // bodies (`def f() ... res:: Response | null = null`). Those land at
+    // module scope where TypeScript treats them as separate bindings —
+    // the function-local `let res;` (emitted untyped by the compiler's
+    // function-top hoist) shadows them, and TS infers `res` purely from
+    // the first assignment. Pulling the type back into the local `let`
+    // makes the typed declaration cover the actual binding the body uses.
+    // Typed-local hoist — pull `let X: T;` declarations out of the DTS
+    // header and merge them into the body's matching function-local
+    // `let X` line.
+    //
+    // The hoist is name-based: it doesn't carry source-scope identity
+    // through the DTS → body merge, so we can only act when the name
+    // is unambiguous on BOTH sides:
+    //
+    //   1. DTS-side: exactly one `let X: T;` candidate. Multiple
+    //      typed declarations of the same name (one per function
+    //      scope, e.g. `def a() … x:: number; def b() … x:: string`)
+    //      are ambiguous — we don't know which body site each one
+    //      came from.
+    //   2. Body-side: exactly one indented `let X` site. Multiple
+    //      same-named locals across functions would all receive the
+    //      same type otherwise, which is wrong even when DTS itself
+    //      is unambiguous.
+    //   3. No module-scope binding for the name. A top-level typed
+    //      declaration (`x:: string = "..."` at module scope) would
+    //      otherwise be hoisted into an unrelated function-local
+    //      `let x;` — different bindings, same name.
+    //
+    // When any check fails, we leave the local untyped and let
+    // TypeScript infer per-binding from the first assignment.
+    const dtsCandidatesByName = new Map(); // name -> [{dtsIdx, typeSuffix}]
+    for (let i = 0; i < dl.length; i++) {
+      const m = dl[i].match(/^let\s+(\w+)\s*:\s*(.+)\s*;\s*$/);
+      if (!m) continue;
+      const name = m[1];
+      const typeBody = m[2];
+      // Disqualify lines that are really initialized declarations
+      // (`let x: T = init;`). Walk the string honoring brackets,
+      // generics, and `=>` so we don't mistake an arrow's `=>` or a
+      // comparison's `>=` for an assignment `=`.
+      let isAssignment = false;
+      {
+        let d = 0, ang = 0;
+        for (let p = 0; p < typeBody.length; p++) {
+          const c = typeBody[p];
+          if (c === '(' || c === '[' || c === '{') d++;
+          else if (c === ')' || c === ']' || c === '}') d--;
+          else if (c === '<') ang++;
+          else if (c === '>') ang = Math.max(0, ang - 1);
+          else if (c === '=' && d === 0 && ang === 0 &&
+                   typeBody[p + 1] !== '>' && typeBody[p - 1] !== '=' &&
+                   typeBody[p - 1] !== '!' && typeBody[p - 1] !== '<' &&
+                   typeBody[p - 1] !== '>') {
+            isAssignment = true;
+            break;
+          }
+        }
+      }
+      if (isAssignment) continue;
+      const typeSuffix = ': ' + typeBody.trim();
+      if (!dtsCandidatesByName.has(name)) dtsCandidatesByName.set(name, []);
+      dtsCandidatesByName.get(name).push({ dtsIdx: i, typeSuffix });
+    }
+
+    const localTypedLetIdxs = new Set();
+    for (const [name, candidates] of dtsCandidatesByName) {
+      const { dtsIdx, typeSuffix } = candidates[0];
+      // DTS-side collision: same name typed in two function scopes.
+      // We can't tell which body site each DTS line came from, so
+      // strip both — the locals fall back to per-binding inference.
+      if (candidates.length !== 1) {
+        for (const c of candidates) localTypedLetIdxs.add(c.dtsIdx);
+        continue;
+      }
+      const localPat = new RegExp(`^\\s+let\\s+(?:[^;=]*?\\b)?${name}\\b(?!\\s*:)([^;=]*?)?;`);
+      // Module-scope binding probe: a non-indented `let`/`const`/`var`/
+      // export of the same name, or a bare `name = ...` at the start
+      // of a line. If any exist, this DTS declaration belongs to that
+      // module-scope binding, not to a function-local — leave the DTS
+      // declaration alone (it IS the typed declaration for that
+      // top-level binding).
+      const moduleScopePat = new RegExp(
+        `^(?:export\\s+(?:default\\s+)?)?(?:const|let|var)\\s+(?:[^;=]*?\\b)?${name}\\b|^${name}\\s*=`,
+      );
+      let hasModuleScope = false;
+      let localLine = -1;
+      let multipleLocals = false;
+      for (let j = 0; j < cl.length; j++) {
+        if (moduleScopePat.test(cl[j])) { hasModuleScope = true; break; }
+        if (!localPat.test(cl[j])) continue;
+        if (localLine >= 0) { multipleLocals = true; break; }
+        localLine = j;
+      }
+      if (hasModuleScope) continue;
+      // Body-side collision: multiple function-local `let X` sites
+      // for one DTS declaration. We don't know which one was the
+      // intended source. Strip the DTS line so it doesn't bleed into
+      // the wrong scope; the locals fall back to per-binding inference.
+      if (multipleLocals) { localTypedLetIdxs.add(dtsIdx); continue; }
+      // No local site found: this is genuinely a module-scope typed
+      // declaration (no function-local to hoist into). Leave the DTS
+      // line in place — it's the `let name: T;` declaration the body's
+      // top-level `name = value` needs to type-check.
+      if (localLine < 0) continue;
+      // Single unambiguous match — perform the hoist.
+      cl[localLine] = cl[localLine].replace(
+        new RegExp(`(\\blet\\s[^;]*?\\b${name}\\b)(?!\\s*:)`),
+        `$1${typeSuffix}`,
+      );
+      localTypedLetIdxs.add(dtsIdx);
+    }
+    if (localTypedLetIdxs.size > 0) {
+      for (const i of localTypedLetIdxs) dl[i] = '';
+    }
+
     const fnSigs = [];
     for (let i = 0; i < dl.length; i++) {
       const m = dl[i].match(/^(?:export\s+)?(?:declare\s+)?function\s+(\w+)/);
@@ -722,9 +993,22 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
       const injections = [];
       const moved = new Set();
       for (const fn of fnSigs) {
-        const pat = new RegExp(`^(?:export\\s+)?(?:async\\s+)?function\\s+${fn.name}\\s*[(<]`);
+        // Match the impl in either of two shapes:
+        //   1. top-level: `function NAME(`, `function NAME<`,
+        //      `async function NAME(`, `export function NAME(`
+        //   2. bare-name arrow assignment: `NAME = function(`,
+        //      `NAME = async function(`, `NAME = function*(`
+        // Pattern (2) is how Rip emits arrow assignments at module
+        // scope: `name = (...) -> ...` becomes `name = function(...) {…}`.
+        // We deliberately do NOT match `obj.NAME = function(`: the DTS
+        // emits `declare function NAME(...)` only for module-scope,
+        // bare-name arrow assignments. A property-style match would
+        // pick up an unrelated `obj.NAME = ...` line that happens to
+        // share the function name and apply the wrong signature there.
+        const topLevelPat = new RegExp(`^(?:export\\s+)?(?:async\\s+)?function\\s+${fn.name}\\s*[(<]`);
+        const arrowAssignPat = new RegExp(`^\\s*${fn.name}\\s*=\\s*(?:async\\s+)?function\\s*\\*?\\s*\\(`);
         for (let j = 0; j < cl.length; j++) {
-          if (pat.test(cl[j])) {
+          if (topLevelPat.test(cl[j]) || arrowAssignPat.test(cl[j])) {
             injections.push({ codeLine: j, sig: fn.sig });
             moved.add(fn.idx);
             break;
@@ -775,7 +1059,13 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
           const sig = inj.sig.replace(/^declare /, '');
           const sigParams = extractFnParams(sig);
           if (sigParams !== null) {
-            cl[inj.codeLine] = replaceFnParams(cl[inj.codeLine], sigParams);
+            // Merge in the impl's default values BEFORE replacing — keeps
+            // `name?: T` on the overload (caller view) but writes
+            // `name: T = default` into the impl signature (body view) so
+            // TypeScript sees the body's `opts` as `T`, not `T | undefined`.
+            const implParams = extractFnParams(cl[inj.codeLine]);
+            const merged = mergeSigWithImplDefaults(sigParams, implParams);
+            cl[inj.codeLine] = replaceFnParams(cl[inj.codeLine], merged);
           }
           const typeParams = extractTypeParams(sig);
           if (typeParams) {
@@ -1154,16 +1444,37 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
     const cl = code.split('\n');
     const reEsc = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-    // Build DTS header type map for merging
+    // Build DTS header type map for merging. The map is name-based,
+    // and the inline-let pass below uses it to inject types into
+    // function-top hoist `let X;` declarations.
+    //
+    // DTS-side collision: when the same name appears in multiple
+    // `let X: T;` lines with different types (one per independent
+    // function scope), `letTypes.set` would otherwise let the last
+    // one win and silently apply the wrong type. Detect the conflict
+    // and remove the name from the map so the inline-let pass leaves
+    // those locals untyped (TS infers per-binding from the first
+    // assignment, which is the correct fallback). The typed-local
+    // hoist above also handles body-side ambiguity for the cases
+    // where the inline-let pass doesn't fire.
     const letTypes = new Map();
+    const ambiguousLetNames = new Set();
     const movedDts = new Set();
     let dl;
     if (headerDts) {
       dl = headerDts.split('\n');
       for (let i = 0; i < dl.length; i++) {
         const m = dl[i].match(/^(?:export\s+)?(?:declare\s+)?let\s+(\w+):\s+(.+);$/);
-        if (m) letTypes.set(m[1], { type: m[2], idx: i });
+        if (!m) continue;
+        const [, name, type] = m;
+        const prev = letTypes.get(name);
+        if (prev) {
+          if (prev.type !== type) ambiguousLetNames.add(name);
+          continue;
+        }
+        letTypes.set(name, { type, idx: i });
       }
+      for (const name of ambiguousLetNames) letTypes.delete(name);
     }
 
     // Helper: inline a variable at the given line


### PR DESCRIPTION
## Summary

A correctness pass on Rip's type system, surfaced and stress-tested by typing `packages/http/http.rip`. Seven distinct compiler/typecheck bugs fixed, three pre-existing HTTP semantics bugs fixed in the package, and the project default flipped from `strict: true` → `strict: false` so the language now matches its own stated philosophy ("types are optional, design scaffolding").

Most of the change lives in `src/dts.js` and `src/typecheck.js`. Only ~38 lines touched `src/compiler.js` / `src/lexer.js`, and they're minimal defensive guards (handle String-wrapper identifiers, allow `void` in type-alias body unions).

## Compiler / type-system fixes

- **`lexer.js`** — allow `void` in type-alias body unions and generics (`type Foo = T | void`, `Promise<void>` mid-expression).
- **`compiler.js`** — `collectFunctionVariables` now handles String-wrapper identifiers; without this, typed locals leaked to the global scope instead of getting a function-top `let`.
- **`compiler.js`** — `@field:: T` constructor params: unwrap String wrappers in `atParamMap` so `super("...#{@field}...")` references resolve to the renamed `_field` parameter (the typed path was previously emitting `this.field` before super assignment).
- **`dts.js`** — stop emitting `export default x` (it's a runtime statement, not a type declaration; the body provides it). Previously triggered TS2528 false positives in any typed file.
- **`dts.js`** — emit `_field` for subclass-constructor `@`-shorthand params so the shadow body's `_field` references resolve correctly.
- **`dts.js`** — scope-aware emission for nested arrow assignments: `let X: T;` inside function bodies, `declare function X(...)` at module scope. Previously emitted phantom module-scope declarations that shadowed function-locals.
- **`dts.js`** — `collectParams` default-skip stops at `PARAM_END` (was only matching `CALL_END`, causing arrow param lists to over-consume tokens past their close).
- **`typecheck.js`** — `mergeSigWithImplDefaults` so the impl signature sees `opts: T = {}` instead of `opts?: T`. Keeps the overload caller-view optional while letting the body narrow `opts` to `T`. Identifier-aware angle/string-aware scanners handle `=>`, generics, comparisons, and string defaults without confusing the param parser.
- **`typecheck.js`** — typed-local hoist with name-collision and module-scope guards. After three rounds of GPT-5.5 review caught corner cases (DTS-side collision, body-side collision, module-scope-vs-local), it skips the hoist whenever scope-soundness can't be guaranteed by name alone, leaving the local untyped rather than risking the wrong type.
- **`typecheck.js`** — nested-arrow impl matching for `name = function(...)` patterns so DTS sigs reach their impls. Previously only top-level `function name(...)` declarations got typed params injected.

## `http.rip` changes

- **Add typed public API**: `HttpOptions`, `RetryConfig`, `RetryOption`, hook function types + `BeforeRetryInfo`, `Hooks`, `HttpInstance`, plus `HTTPError`/`TimeoutError` field types via `interface` declaration merging. Path 2 trim — types at the consumer boundary, inference inside.
- **Pre-existing HTTP semantics bugs surfaced during typing**:
  - `json: null` was silently dropped (`opts.json?` conflated null-as-absent). Now uses `'json' of opts and opts.json isnt undefined` and sends the literal `"null"` body with `application/json`.
  - Caller aborts via `opts.signal` were re-branded as `TimeoutError`. Now composes via `AbortSignal.any([opts.signal, timeoutSignal])` and rethrows the original `AbortError` in the catch block when the caller aborted.
  - Failed retryable responses are now body-cancelled (`try res.body?.cancel()`) before retry to free the underlying connection.

## Default strictness

`createTypeCheckSettings` now defaults to `strict: false`, `noImplicitAny: false`, `strictNullChecks: false`. Aligns with Rip's stated philosophy ("types are optional, design scaffolding, not safety rails") and matches gradual-typing defaults across comparable systems (Sorbet's `# typed: false`, mypy's permissive default, Hack's `partial`, pre-strict TypeScript). Projects opt UP via `rip.json: { "strict": true }`.

This is the structural change. The `http.rip` line-count win is small (-11 lines) but the language now feels less type-heavy by default.

## Test plan

- [x] `bun run test` — 2138/2138 passing
- [x] `bun run test:types` — 35/35 passing (audit suite intact across the strict flip — no `# @ts-expect-error` directives became unused)
- [x] `bun run test:schema` — 8/8 passing
- [x] `bun run test:graph` — bundle graph clean
- [x] `rip check packages/http` — 0 errors (was 40 before this work)
- [x] Live HTTP test against httpbin.org — GET, POST with `json:`, `HTTPError` catch, `extend()` all work
- [x] HTTP semantics regressions verified end-to-end:
  - `http.post! url, json: null` → body `"null"`, `Content-Type: application/json`
  - `controller.abort(); http url, signal: controller.signal` → throws original `AbortError`
  - `http url, timeout: 100, retry: 0` against slow endpoint → throws `TimeoutError`

## Review notes

- Three rounds with GPT-5.5 over the MCP `user-ai` provider. Each round caught real bugs in my own fixes (notably the typed-local hoist scope-soundness across multiple passes). Worth doing on any non-trivial compiler change going forward.
- The remaining ~80 lines of types in `http.rip` that didn't trim are the cost of `HttpOptions` (19 fields, 21 lines) plus the hook contract — load-bearing for consumers, not internal documentation.
- Some scanner heuristics in `typecheck.js` (`splitTopLevelParams`, `findOuterDefault`) are pragmatic, not bulletproof — see the inline comments. Edge cases with `<` as comparison vs generic-open in default expressions are documented as known limitations.