### PR TITLE
RFC 2: Rip packages exposing types to typed Rip apps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,15 @@ rip -cm example.rip
 > calls (`div outline` — text child) and imperative calls outside
 > `render` (`Btn(outline)` — positional arg) are unaffected.
 
+> **CRITICAL — `::` binds a name to a type; `:` separates fields inside a type literal `{ ... }`:**
+>
+> - `def foo(opts:: { host?: string, port?: number })` — CORRECT
+> - `def foo(opts:: { host?:: string })` — ERROR (`::` rejected inside type literal)
+> - `def foo({name:: string, age:: number})` — CORRECT (destructuring pattern, not a type literal)
+>
+> Rule of thumb: in a param list `({...})` is destructuring (each binding uses `::`);
+> after `::` you're in a type expression (fields use `:`, TS-style).
+
 ### Removed (from CoffeeScript / Rip 2.x)
 
 | Feature                            | Replacement                                           |
@@ -339,7 +348,7 @@ rip -cm example.rip
 | dotted keys           | `{a.b: 1}`       | flat string key in object literals         |
 | map literal           | `*{a: 1}`        | real `Map` with any key type               |
 | symbol literal        | `:redo`          | interned symbol via `Symbol.for('redo')`   |
-| optional prop / param | `name?:: T`      | `?` before `::` marks the name optional (params, type fields, component props, structural literals) |
+| optional prop / param | `name?:: T`      | `?` before `::` marks the name optional (params, type fields). Inside a type literal `{ ... }`, use `name?: T` (TS-style) |
 | boolean prop shorthand | `Btn outline, link` | JSX-style `{outline: true, link: true}` for child components in `render` |
 
 ### Kept

--- a/RFCS.md
+++ b/RFCS.md
@@ -36,12 +36,12 @@ Design proposals under discussion. Grouped by domain.
 
 **Scope — four parse contexts where `?::` should mean "optional".** Today only two of the four honor the marker; the other two silently drop it. RFC 1 unifies the rule across all four.
 
-| Context                                             | Example                            | Works today?                                                                |
-| --------------------------------------------------- | ---------------------------------- | --------------------------------------------------------------------------- |
-| Function/method params                              | `def f(x?:: T)`                    | ✅ — lexer predicate → DTS `x?: T`                                           |
-| Named type alias fields                             | `type T = { x?:: string }`         | ✅ — same flag, same DTS path                                                |
-| **Component prop declarations**                     | `@label?:: string`                 | ❌ — components emitter ignores `?` on prop names; keys optionality off `:=` |
-| **Structural type literals in annotation position** | `(opts:: { search?:: string }) ->` | ❌ — the `?` is silently stripped, every field types as required             |
+| Context                                             | Example                           | Works today?                                                                |
+| --------------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------- |
+| Function/method params                              | `def f(x?:: T)`                   | ✅ — lexer predicate → DTS `x?: T`                                           |
+| Named type alias fields                             | `type T = { x?: string }`         | ✅ — same flag, same DTS path                                                |
+| **Component prop declarations**                     | `@label?:: string`                | ❌ — components emitter ignores `?` on prop names; keys optionality off `:=` |
+| **Structural type literals in annotation position** | `(opts:: { search?: string }) ->` | ❌ — the `?` is silently stripped, every field types as required             |
 
 The two failing cases share a root: the predicate flag is set on the property name but never consulted by the emitter for that context. The structural-literal failure is particularly silent — no parse error, no warning, just every field treated as required at the call site (caught only when the type checker rejects partial calls).
 
@@ -898,12 +898,12 @@ No backwards-compatibility shim. The bundle JSON is regenerated on every `serve`
 
 The bundler categorizes every entry by where it came from and prefixes accordingly:
 
-| Prefix    | Origin                                                                  | Today's keying                              |
-| --------- | ----------------------------------------------------------------------- | ------------------------------------------- |
-| `_route/` | URL-addressable route files (the file-based router's input)             | `components/<path>` (bare)                  |
-| `_app/`   | Auto-scanned `appDir` files (`bundle: { app: ['.'] }` — the `'.'` part) | `components/_lib/<path>` (overloaded)       |
-| `_lib/`   | Author-declared extra dirs (`bundle: { app: ['./widgets'] }`)           | `components/_lib/<dir-name>/<path>`         |
-| `_pkg/`   | RFC 9 auto-discovered packages                                          | (new — RFC 9 reused `_lib/<pkg-name>/...`)  |
+| Prefix    | Origin                                                                  | Today's keying                             |
+| --------- | ----------------------------------------------------------------------- | ------------------------------------------ |
+| `_route/` | URL-addressable route files (the file-based router's input)             | `components/<path>` (bare)                 |
+| `_app/`   | Auto-scanned `appDir` files (`bundle: { app: ['.'] }` — the `'.'` part) | `components/_lib/<path>` (overloaded)      |
+| `_lib/`   | Author-declared extra dirs (`bundle: { app: ['./widgets'] }`)           | `components/_lib/<dir-name>/<path>`        |
+| `_pkg/`   | RFC 9 auto-discovered packages                                          | (new — RFC 9 reused `_lib/<pkg-name>/...`) |
 
 The runtime resolver `resolveStorePath` ([packages/app/index.rip:908–922](packages/app/index.rip#L908-L922)) currently tries `components/_lib/{clean}` then `components/{clean}` — a two-step walk with `_lib/` deterministically winning ties. After this RFC the resolver does a single lookup against the `modules` map per category branch: try `_pkg/{clean}`, then `_lib/{clean}`, then `_app/{clean}`, then `_route/{clean}`. The `_pkg/` branch's exact resolution semantics — entry-file lookup, sub-path imports — are TBD and tracked with the package-shape work in [RFC 9 §5](#5-package-shape-contract); this RFC just reserves the prefix.
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "rip-lang",
       "devDependencies": {
+        "@types/bun": "1.3.14",
         "typescript": "5.9.3",
       },
     },
@@ -25,6 +26,7 @@
     },
     "packages/db": {
       "name": "@rip-lang/db",
+      "version": "2.0.1",
       "bin": {
         "rip-db": "./bin/rip-db",
       },
@@ -205,11 +207,17 @@
 
     "@rip-lang/x12": ["@rip-lang/x12@workspace:packages/x12"],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+
     "axe-core": ["axe-core@4.11.3", "", {}, "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
@@ -238,6 +246,8 @@
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "author": "Steve Shreeve <steve.shreeve@gmail.com>",
   "license": "MIT",
   "devDependencies": {
+    "@types/bun": "1.3.14",
     "typescript": "5.9.3"
   }
 }

--- a/packages/server/api.rip
+++ b/packages/server/api.rip
@@ -24,16 +24,16 @@ import { posix } from 'node:path'
 # Module State
 # ==============================================================================
 
-_                     = null  # Match capture holder for Rip's =~
-_errorHandler         = null  # Custom error handler
-_notFoundHandler      = null  # Custom 404 handler
-_rawFilter            = null  # Raw request filter (before body parsing)
-_beforeFilters        = []    # Before request filters
-_afterFilters         = []    # After request filters
-_routes               = []    # Route definitions
-_middlewares          = []    # Global middleware functions
-_prefix               = ''    # Current route prefix for grouping
-_corsPreflightPolicy  = null  # Policy fn set by cors middleware: see setCorsPreflightPolicy
+_:: RegExpMatchArray | null            = null  # Match capture holder for Rip's =~
+_errorHandler:: Function | null        = null  # Custom error handler
+_notFoundHandler:: Function | null     = null  # Custom 404 handler
+_rawFilter:: Function | null           = null  # Raw request filter (before body parsing)
+_beforeFilters:: Function[]            = []    # Before request filters
+_afterFilters:: Function[]             = []    # After request filters
+_routes:: any[]                        = []    # Route definitions
+_middlewares:: Function[]              = []    # Global middleware functions
+_prefix:: string                       = ''    # Current route prefix for grouping
+_corsPreflightPolicy:: Function | null = null  # Policy fn set by cors middleware: see setCorsPreflightPolicy
 
 export resetGlobals = ->
   _errorHandler        = null
@@ -73,7 +73,7 @@ export setCorsPreflightPolicy = (fn) ->
 export enableCorsPreflight = -> null
 
 # AsyncLocalStorage for request context (enables sync read() in handlers)
-export requestContext = new AsyncLocalStorage()
+export requestContext:: AsyncLocalStorage<{ env?: any, data: any }> = new AsyncLocalStorage()
 
 # ==============================================================================
 # Router: Pattern Compiler
@@ -186,7 +186,7 @@ createContext = (req, params = {}) ->
       out.set 'ETag', etag
       new Response file, { status: 200, headers: out }
 
-    header: (name, value, opts = {}) ->
+    header: (name, value, opts:: { append?: boolean } = {}) ->
       if value?
         if opts.append then out.append(name, value) else out.set(name, value)
         return
@@ -396,7 +396,7 @@ export fetch = (req) ->
   _rawFilter?.(req) if method in ['POST', 'PUT', 'PATCH']
 
   # Pre-parse body and query for sync read() — baked in, zero ceremony
-  data = {}
+  data:: any = {}
   try
     ct = req.headers.get('content-type') or ''
     if method in ['POST', 'PUT', 'PATCH']
@@ -445,7 +445,7 @@ runHandler = (c, handler) ->
 
 export startHandler = -> fetch
 
-export start = (opts = {}) ->
+export start = (opts?:: { host?: string, port?: number, silent?: boolean }) ->
   handler = startHandler()
 
   # If running under rip-server, set global handler and return
@@ -508,7 +508,7 @@ export session = new Proxy {},
     true
 
 # Env proxy — access env.FOO anywhere (shortcut for process.env)
-export env = new Proxy {}, get: (_, key) -> process.env[key]
+export env = new Proxy {}, get: (_, key) -> process.env[String(key)]
 
 # ==============================================================================
 # Error Helpers — Halt request with an HTTP error
@@ -541,7 +541,7 @@ export isBlank = (obj) ->
 
 capitalize = (str) -> str.charAt(0).toUpperCase() + str.slice(1).toLowerCase()
 
-toMoney = (value, half, cents) ->
+toMoney = (value, half = false, cents = false) ->
   m = value.replace(/[$, ]/g, '').match(/^([-+]?)(\d*)\.?(\d*)$/)
   return null unless m
   intp = m[2] or ''
@@ -672,8 +672,8 @@ export validators =
       Array.from(new Set(nums)).sort((a, b) -> a - b)
     catch then null
 
-export registerValidator = (name, fn) -> validators[name] = fn
-export getValidator      = (name)     -> validators[name]
+export registerValidator = (name:: string, fn:: (v: any) => any) -> validators[name] = fn
+export getValidator      = (name:: string)                       -> validators[name]
 
 # ==============================================================================
 # check() — Apply a Validator to an Arbitrary Value
@@ -695,7 +695,7 @@ export check = (value, type) ->
 # read() — Sinatra-style Parameter Reading
 # ==============================================================================
 
-export read = (name = null, type = null, miss = null) ->
+export read = (name?:: string, type?:: string | RegExp | any[] | Record<string, any>, miss?:: any) ->
   store = requestContext.getStore() or throw new Error 'no context for read()'
 
   # missing value helper
@@ -740,7 +740,7 @@ export read = (name = null, type = null, miss = null) ->
   # Array: [min, max] constraint or enumeration
   else if Array.isArray(type)
     s = String(v ?? '')
-    y = true
+    y:: boolean = true
     if typeof type[0] is 'number'
       [min, max] = type
       if typeof v is 'number' or (s =~ /^[-+]?\d+$/)
@@ -762,7 +762,7 @@ export read = (name = null, type = null, miss = null) ->
       n = if s =~ /^[-+]?\d+$/ then +s else NaN
       v = if not isNaN(n) and (not type.start? or n >= type.start) and (not type.end? or n <= type.end) then n else null
     else if type.min? or type.max?
-      y = true
+      y:: boolean = true
       if typeof v is 'number' or (s =~ /^[-+]?\d+$/)
         n = if typeof v is 'number' then v else +s
         y = false if type.min? and n < type.min

--- a/packages/server/middleware.rip
+++ b/packages/server/middleware.rip
@@ -38,7 +38,15 @@ import { fileURLToPath } from 'node:url'
 import { dirname, resolve, relative } from 'node:path'
 import { existsSync, realpathSync } from 'node:fs'
 
-export cors = (opts = {}) ->
+export cors = (opts:: {
+  origin?: string | string[] | ((origin: string) => boolean)
+  methods?: string | string[]
+  headers?: string | string[]
+  credentials?: boolean
+  maxAge?: number
+  exposeHeaders?: string | string[]
+  preflight?: boolean
+} = {}) ->
   origin        = opts.origin or '*'
   methods       = opts.methods or 'GET,POST,PUT,PATCH,DELETE,OPTIONS'
   headers       = opts.headers or 'Content-Type,Authorization,X-Requested-With'
@@ -112,7 +120,11 @@ export cors = (opts = {}) ->
 #   stream: { write: (msg) -> } (default: console)
 #
 
-export logger = (opts = {}) ->
+export logger = (opts:: {
+  format?: 'tiny' | 'short' | 'dev' | 'full' | ((info: any) => string)
+  skip?: (c: any) => boolean
+  stream?: { write: (msg: string) => any }
+} = {}) ->
   format = opts.format or 'dev'
   skip = opts.skip or null
   stream = opts.stream or { write: (msg) -> p msg.trim() }
@@ -161,7 +173,7 @@ export logger = (opts = {}) ->
 # Note: Requires Bun's built-in compression support
 #
 
-export compress = (opts = {}) ->
+export compress = (opts:: { threshold?: number, encodings?: string[] } = {}) ->
   threshold = opts.threshold or 1024
   encodings = opts.encodings or ['gzip', 'deflate']
 
@@ -285,7 +297,7 @@ b64urlToU8 = (s) ->
   pad = s.length % 4
   s += '='.repeat(4 - pad) if pad
   bin = atob(s)
-  Uint8Array.from(bin, (c) -> c.charCodeAt(0))
+  Uint8Array.from(bin, (c:: string) -> c.charCodeAt(0))
 
 deriveAesKey = (secret) ->
   encoder = new TextEncoder()
@@ -341,7 +353,15 @@ decodeSession = (cookie, secret, encrypt) ->
   catch
     {}
 
-export sessions = (opts = {}) ->
+export sessions = (opts:: {
+  secret?: string
+  encrypt?: boolean
+  name?: string
+  maxAge?: number
+  secure?: boolean
+  httpOnly?: boolean
+  sameSite?: 'Strict' | 'Lax' | 'None'
+} = {}) ->
   secret     = opts.secret
   encrypt    = opts.encrypt is true
   cookieName = opts.name or 'session'
@@ -470,7 +490,15 @@ tokensEqual = (a, b) ->
 
 SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS'])
 
-export csrf = (opts = {}) ->
+export csrf = (opts:: {
+  cookieName?: string
+  headerName?: string
+  fieldName?: string
+  secret?: string
+  secure?: boolean
+  sameSite?: 'Strict' | 'Lax' | 'None'
+  exempt?: (c: any) => boolean
+} = {}) ->
   cookieName = opts.cookieName or 'csrf_token'
   headerName = opts.headerName or 'X-CSRF-Token'
   fieldName  = opts.fieldName  or '_csrf'
@@ -559,7 +587,13 @@ export csrf = (opts = {}) ->
 #   Content-Security-Policy (optional)
 #
 
-export secureHeaders = (opts = {}) ->
+export secureHeaders = (opts:: {
+  frameOptions?: string
+  referrerPolicy?: string
+  contentSecurityPolicy?: string
+  hsts?: boolean
+  hstsMaxAge?: number
+} = {}) ->
   (c, next) ->
     c.header 'X-Content-Type-Options', 'nosniff'
     c.header 'X-Frame-Options', opts.frameOptions or 'DENY'
@@ -585,7 +619,7 @@ export secureHeaders = (opts = {}) ->
 #   status: number (status code, default 408)
 #
 
-export timeout = (opts = {}) ->
+export timeout = (opts:: { ms?: number, message?: string, status?: number } = {}) ->
   ms = opts.ms or 30000
   message = opts.message or 'Request Timeout'
   status = opts.status or 408
@@ -618,7 +652,7 @@ export timeout = (opts = {}) ->
 #   message: string (error message)
 #
 
-export bodyLimit = (opts = {}) ->
+export bodyLimit = (opts:: { maxSize?: number, message?: string } = {}) ->
   maxSize = opts.maxSize or 1024 * 1024  # 1MB default
   message = opts.message or 'Request body too large'
 
@@ -721,7 +755,18 @@ pre{margin:0;white-space:pre-wrap;word-break:break-word}
 #   watch:      boolean         — enable hot-reload (registers watch dirs with rip-server)
 #
 
-export serve = (opts = {}) ->
+serveRegistered:: boolean = false
+
+export serve = (opts:: {
+  dir?: string
+  routes?: string
+  bundle?: string[] | Record<string, string[]>
+  components?: string[] | Record<string, string[]>
+  app?: string
+  title?: string
+  state?: Record<string, any>
+  watch?: boolean
+} = {}) ->
   prefix        = opts.app or ''
   appDir        = opts.dir or '.'
   routesName    = opts.routes or 'routes'
@@ -753,7 +798,7 @@ export serve = (opts = {}) ->
   hasBrotli = existsSync(bundlePathBr)
 
   # Route: /rip/rip.min.js — serve the bundle, prefer pre-compressed Brotli
-  unless serve._registered
+  unless serveRegistered
     get "/rip/rip.min.js", (c) ->
       # Re-stat per request: the bundle is rebuilt during dev iteration
       # (`bun run build`), and a cached etag captured at registration
@@ -768,7 +813,7 @@ export serve = (opts = {}) ->
       headers = { 'Content-Type': 'application/javascript', 'Cache-Control': 'no-cache', 'ETag': baseEtag }
       headers['Content-Encoding'] = 'br' if useBr
       new Response (if useBr then Bun.file(bundlePathBr) else Bun.file(bundlePath)), { headers }
-    serve._registered = true
+    serveRegistered = true
 
   # Route: {prefix}/*.rip — serve .rip files from the app directory tree
   appDirResolved = realpathSync(resolve(appDir))
@@ -790,7 +835,8 @@ export serve = (opts = {}) ->
     components = {}
     hasRoutes = false
     if includeRoutes and existsSync(routesDir)
-      for path in Array.from(glob.scanSync(routesDir)).sort()
+      routePaths:: string[] = Array.from(glob.scanSync(routesDir), String).sort()
+      for path in routePaths
         components["components/#{path}"] = Bun.file("#{routesDir}/#{path}").text!
         hasRoutes = true
     for dir in dirs
@@ -798,7 +844,8 @@ export serve = (opts = {}) ->
       isExternal = rel.startsWith('..')
       isAppDir   = rel is '' or rel is '.'
       keyPrefix  = if isExternal then name else if isAppDir then '' else rel
-      for path in Array.from(glob.scanSync(dir)).sort()
+      dirPaths:: string[] = Array.from(glob.scanSync(dir), String).sort()
+      for path in dirPaths
         continue if path is 'index.rip' or path.endsWith('/index.rip')
         # In auto-scan mode, skip the routes/ subtree (already keyed by routes branch above)
         continue if isAppDir and (path is routesName or path.startsWith("#{routesName}/"))
@@ -806,7 +853,7 @@ export serve = (opts = {}) ->
         components[key] = Bun.file("#{dir}/#{path}").text! unless components[key]
     bundle = { components }
     if includeRoutes
-      data = {}
+      data:: Record<string, any> = {}
       data.title = appTitle if appTitle
       data.watch = enableWatch
       data.router = true if hasRoutes

--- a/packages/server/tests/csrf.rip
+++ b/packages/server/tests/csrf.rip
@@ -6,7 +6,7 @@ import { csrf } from '../middleware.rip'
 # Run the middleware once. Headers and cookies arrive as plain hash;
 # `mutate` lets a test poke at the context before the inner handler
 # runs (typically to set csrfToken-driven response state).
-runCsrf = (opts, method, headers = {}, mutate) ->
+runCsrf = (opts, method, headers = {}, mutate = null) ->
   mw = csrf(opts)
   c =
     csrfToken: null

--- a/packages/vscode/src/lsp.js
+++ b/packages/vscode/src/lsp.js
@@ -213,6 +213,7 @@ function rebuildProjectInfo() {
   projectRoots.clear();
   projectRootCache.clear();
   bareSpecForEntry.clear();
+  entryForBareSpec.clear();
   (function walk(dir) {
     let entries;
     try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
@@ -252,6 +253,7 @@ const projectRootCache = new Map();      // Map<dir, projectRoot|null>
 // Files that are the entry point of a workspace package, mapped to the bare
 // specifier callers should use (e.g. '@rip-lang/server', '@rip-lang/server/middleware').
 const bareSpecForEntry = new Map();      // Map<fp, bareSpec>
+const entryForBareSpec = new Map();      // Map<bareSpec, fp> — reverse of above, used to resolve bare imports
 
 function findProjectRoot(fp) {
   const dir = path.dirname(fp);
@@ -287,6 +289,7 @@ function loadPackageJson(dir) {
     const full = path.resolve(dir, target);
     const spec = sub === '.' ? pkg.name : pkg.name + sub.slice(1);
     bareSpecForEntry.set(full, spec);
+    entryForBareSpec.set(spec, full);
   };
   if (pkg.exports && typeof pkg.exports === 'object') {
     for (const [sub, target] of Object.entries(pkg.exports)) addEntry(sub, target);
@@ -817,7 +820,11 @@ function publishDiagnostics(filePath) {
 // ── TypeScript Language Service ────────────────────────────────────
 
 function createService() {
-  const settings = tc.createTypeCheckSettings(ts);
+  const { typeRoots, types: ambientTypes } = tc.collectAmbientTypes(rootPath);
+  const settings = tc.createTypeCheckSettings(ts, {
+    ...(typeRoots.length ? { typeRoots } : {}),
+    ...(ambientTypes.length ? { types: ambientTypes } : {}),
+  });
 
   const host = {
     getScriptFileNames: () => [...compiled.keys()].map(toVirtual),
@@ -836,6 +843,14 @@ function createService() {
     getDirectories: (...a) => ts.sys.getDirectories(...a),
     directoryExists: (...a) => ts.sys.directoryExists(...a),
 
+    resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference, options) {
+      return typeDirectiveNames.map((name) => {
+        const n = typeof name === 'string' ? name : name.name;
+        const r = ts.resolveTypeReferenceDirective(n, containingFile, options || settings, ts.sys, redirectedReference);
+        return r.resolvedTypeReferenceDirective;
+      });
+    },
+
     resolveModuleNames(names, containingFile) {
       return names.map((name) => {
         if (name.endsWith('.rip')) {
@@ -845,6 +860,18 @@ function createService() {
           }
           if (compiled.has(resolved)) {
             return { resolvedFileName: toVirtual(resolved), extension: '.ts', isExternalLibraryImport: false };
+          }
+        }
+        // @rip-lang/* (and any workspace package) bare-spec resolution: if the
+        // spec matches a known workspace package entry that resolves to a .rip
+        // file, compile it and return a virtual .rip.ts so TS sees its exports.
+        if (name.startsWith('@') || !name.startsWith('.')) {
+          const resolved = entryForBareSpec.get(name);
+          if (resolved && fs.existsSync(resolved)) {
+            if (!compiled.has(resolved)) compileRip(resolved, fs.readFileSync(resolved, 'utf8'));
+            if (compiled.has(resolved)) {
+              return { resolvedFileName: toVirtual(resolved), extension: '.ts', isExternalLibraryImport: false };
+            }
           }
         }
         const r = ts.resolveModuleName(name, containingFile, settings, {

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -423,6 +423,47 @@ export class CodeEmitter {
       ripSrcCache.set(genLineInStmt, v);
       return v;
     };
+    // Inline type annotations (emitted when `inlineTypes: true`) inject
+    // identifiers into function-signature lines that have no source
+    // counterpart — e.g. `header(name, value, opts: { append?: boolean })`.
+    // Their identifiers (`append`, `boolean`, etc.) would otherwise compete
+    // with real body identifiers in the regex matcher below, mis-mapping
+    // source positions onto the type literal. Detect those brace ranges
+    // per line and skip matches inside them.
+    const inlineTypeRangesCache = new Map();
+    const getInlineTypeRanges = (genLineInStmt) => {
+      if (inlineTypeRangesCache.has(genLineInStmt)) return inlineTypeRangesCache.get(genLineInStmt);
+      const lt = codeLines[genLineInStmt];
+      const ranges = [];
+      // Only look at function-signature shaped lines: contain `(...) {` or `(...) =>`.
+      if (lt && /\)\s*(\{|=>)\s*$/.test(lt)) {
+        // Find `: {` after an identifier (with optional `?` and whitespace).
+        const annotRe = /\b[a-zA-Z_$][\w$]*\??\s*:\s*\{/g;
+        let am;
+        while ((am = annotRe.exec(lt)) !== null) {
+          const braceStart = am.index + am[0].length - 1; // position of `{`
+          // Skip inside strings (defensive — unlikely here)
+          if (CodeEmitter._isColInsideString(lt, braceStart)) continue;
+          // Walk to matching `}` honoring brace depth and strings
+          let depth = 1, j = braceStart + 1, inStr = false, quote = '';
+          while (j < lt.length && depth > 0) {
+            const ch = lt[j];
+            if (inStr) {
+              if (ch === '\\') { j += 2; continue; }
+              if (ch === quote) inStr = false;
+            } else if (ch === '"' || ch === "'" || ch === '`') {
+              inStr = true; quote = ch;
+            } else if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+            j++;
+          }
+          ranges.push([braceStart, j]); // exclude positions [braceStart, j)
+          annotRe.lastIndex = j;
+        }
+      }
+      inlineTypeRangesCache.set(genLineInStmt, ranges);
+      return ranges;
+    };
     for (let { name, origLine, origCol } of subs) {
       let escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       let re = new RegExp('\\b' + escaped + '\\b', 'g');
@@ -442,6 +483,11 @@ export class CodeEmitter {
         const annotSrc = getRipSrcAnnot(genLineInStmt);
         const annotMatches = annotSrc != null && annotSrc === origLine;
         if (lineText && CodeEmitter._isColInsideString(lineText, genCol) && !annotMatches) continue;
+        // Skip matches inside inline type annotation brace ranges (e.g.
+        // `opts: { append?: boolean }`) — those identifiers are emitted
+        // for TS type-checking only and have no real source counterpart.
+        const itRanges = getInlineTypeRanges(genLineInStmt);
+        if (itRanges.length && itRanges.some(([s, e]) => genCol >= s && genCol < e)) continue;
         let genLine = lineOffset + genLineInStmt;
         // Annotation-matched lines are the authoritative gen position for
         // their source line — score them as a perfect line match so they
@@ -666,6 +712,41 @@ export class CodeEmitter {
     };
     collect(body);
     return vars;
+  }
+
+  // Walk a function body and collect typed local assignments. Returns a
+  // Map<name, typeString> for every `name:: T = value` whose target is a
+  // String-wrapped identifier carrying `data.type` (attached by types.js).
+  //
+  // Used by `emitBodyWithReturns` in `inlineTypes` mode to annotate the
+  // function-top hoist (`let a, y: boolean, b;`) so shadow-TS sees the
+  // intended type instead of inferring a literal from the first RHS. Stops
+  // at nested function boundaries — each function owns its own typed locals.
+  //
+  // Conflict policy: first annotation wins. Same-name re-annotations are
+  // silently ignored; mixing different types on the same local is an
+  // unusual pattern best surfaced by TS itself once the hoist carries the
+  // first annotation.
+  collectTypedLocals(body) {
+    let typed = new Map();
+    let walk = (sexpr) => {
+      if (!Array.isArray(sexpr)) return;
+      let [head, ...rest] = sexpr;
+      head = str(head);
+      if (Array.isArray(head)) { sexpr.forEach(walk); return; }
+      if (CodeEmitter.ASSIGNMENT_OPS.has(head)) {
+        let [target, value] = rest;
+        if (target instanceof String && target.type && !typed.has(str(target))) {
+          typed.set(str(target), target.type);
+        }
+        walk(value);
+        return;
+      }
+      if (head === 'def' || head === '->' || head === '=>' || head === 'effect') return;
+      rest.forEach(walk);
+    };
+    walk(body);
+    return typed;
   }
 
   // ---------------------------------------------------------------------------
@@ -2776,14 +2857,36 @@ export class CodeEmitter {
 
   formatParam(param) {
     if (typeof param === 'string') return param;
-    if (param instanceof String) return param.valueOf();
-    if (this.is(param, 'rest')) return `...${param[1]}`;
+    if (param instanceof String) {
+      // In `inlineTypes` mode (set by typecheck.compileForCheck), emit the
+      // type annotation inline so shadow TS sees `name: T` for typed params
+      // in every function-like position — top-level arrows, class methods,
+      // object-literal method shorthand, nested functions, etc. The user-
+      // facing `-c` output stays untouched because this flag is off by
+      // default. `.type` carries the raw Rip type string (with `::`),
+      // which converts to TS form by swapping `::` → `:`.
+      if (this.options.inlineTypes && param.type) {
+        return `${param.valueOf()}: ${param.type.replace(/::/g, ':')}`;
+      }
+      return param.valueOf();
+    }
+    if (this.is(param, 'rest')) {
+      // Rest param: `...name`. When the name is a String wrapper carrying
+      // a type, emit `...name: T` so shadow TS sees the rest tuple/array.
+      let restName = param[1];
+      if (this.options.inlineTypes && restName instanceof String && restName.type) {
+        return `...${restName.valueOf()}: ${restName.type.replace(/::/g, ':')}`;
+      }
+      return `...${restName}`;
+    }
     if (this.is(param, 'default')) {
       // `param[1]` is either a plain identifier string (e.g. `x = 5`) or a
       // destructuring pattern AST node (e.g. `{a, b} = {}`). Recurse via
       // `formatParam` so patterns emit as `{a, b}` / `[x, y]` instead of
       // being coerced to a string via `Array.prototype.toString`, which
       // produced the famous `(object,,a,a,,b,b = {})` mis-rendering.
+      // The recursion also picks up any inline type annotation on the
+      // name in `inlineTypes` mode, yielding `name: T = default`.
       return `${this.formatParam(param[1])} = ${this.emit(param[2], 'value')}`;
     }
     if (this.is(param, '.') && param[1] === 'this') return param[2];
@@ -2823,10 +2926,14 @@ export class CodeEmitter {
 
     let paramNames = new Set();
     let extractPN = (p) => {
-      if (typeof p === 'string') paramNames.add(p);
+      // Unwrap String wrappers — typed params arrive as `new String('name')`
+      // with `.data.type` metadata. Without unwrapping, `paramNames.has('name')`
+      // misses (Set compares wrappers by identity), causing the param name to
+      // be re-hoisted as a local `let`, producing duplicate-declaration errors.
+      if (typeof p === 'string' || p instanceof String) paramNames.add(str(p));
       else if (Array.isArray(p)) {
-        if (p[0] === 'rest' || p[0] === '...') { if (typeof p[1] === 'string') paramNames.add(p[1]); }
-        else if (p[0] === 'default') { if (typeof p[1] === 'string') paramNames.add(p[1]); }
+        if (p[0] === 'rest' || p[0] === '...') { if (typeof p[1] === 'string' || p[1] instanceof String) paramNames.add(str(p[1])); }
+        else if (p[0] === 'default') { if (typeof p[1] === 'string' || p[1] instanceof String) paramNames.add(str(p[1])); }
         else if (p[0] === 'array' || p[0] === 'object') this.collectVarsFromArray(p, paramNames);
       }
     };
@@ -2870,7 +2977,20 @@ export class CodeEmitter {
 
       this.indentLevel++;
       let code = '{\n';
-      if (newVars.size > 0) code += this.indent() + `let ${Array.from(newVars).sort().join(', ')};\n`;
+      if (newVars.size > 0) {
+        // In `inlineTypes` mode, propagate `name:: T = value` annotations from
+        // body-level typed assignments onto the hoisted `let`. Without this,
+        // the hoist emits `let y;` (no type), shadow-TS infers from the first
+        // RHS literal (`y = true` → `y: true`), and any later `y = false`
+        // fails TS2322. With this, the hoist emits `let y: boolean;` and the
+        // body's `y = true` / `y = false` both check cleanly.
+        let typedLocals = this.options.inlineTypes ? this.collectTypedLocals(body) : null;
+        let names = Array.from(newVars).sort().map(n => {
+          let t = typedLocals?.get(n);
+          return t ? `${n}: ${t}` : n;
+        });
+        code += this.indent() + `let ${names.join(', ')};\n`;
+      }
 
       let firstIsSuper = autoAssignments.length > 0 && statements.length > 0 &&
                          Array.isArray(statements[0]) && statements[0][0] === 'super';
@@ -4377,6 +4497,11 @@ export class Compiler {
       skipDataPart: this.options.skipDataPart,
       stubComponents: this.options.stubComponents,
       reactiveVars: this.options.reactiveVars,
+      // Emit `name: T` inline on typed params so shadow TS in compileForCheck
+      // sees annotations on every function-like position (top-level arrows,
+      // class methods, object-literal method shorthand, nested functions).
+      // Off by default — only set when producing input for the shadow TS pass.
+      inlineTypes: this.options.inlineTypes,
       // Schema runtime mode: 'browser' / 'validate' / 'server' / 'migration'.
       // Default 'migration' covers the common case (CLI, server, tests) where
       // the user might call any schema feature including .toSQL(). The browser

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -1523,9 +1523,42 @@ export class Lexer {
 
   // Walk back to tag parameters for arrow functions
   tagParameters() {
-    if (this.prevTag() !== ')') return this.tagDoIife();
+    let closeIdx = this.tokens.length - 1;
+    if (this.tokens[closeIdx]?.[0] !== ')') {
+      // Maybe a return-type annotation sits between `)` and the arrow:
+      // `(x:: T):: R ->`. Scan backward over the type expression (balanced
+      // brackets) looking for the trailing `TYPE_ANNOTATION` whose previous
+      // token is `)`. If found, treat that `)` as the param-list close.
+      let n = this.tokens.length;
+      let depth = 0;
+      let j = n - 1;
+      let found = -1;
+      while (j >= 0) {
+        let tk = this.tokens[j];
+        let tg = tk[0];
+        if (tg === ')' || tg === ']' || tg === '}' || tg === 'CALL_END' ||
+            tg === 'PARAM_END' || tg === 'INDEX_END' ||
+            (tg === 'COMPARE' && tk[1] === '>')) {
+          depth++;
+        } else if (tg === '(' || tg === '[' || tg === '{' || tg === 'CALL_START' ||
+                   tg === 'PARAM_START' || tg === 'INDEX_START' ||
+                   (tg === 'COMPARE' && tk[1] === '<')) {
+          depth--;
+        } else if (depth === 0) {
+          if (tg === 'TYPE_ANNOTATION') {
+            if (j > 0 && this.tokens[j - 1][0] === ')') found = j - 1;
+            break;
+          }
+          if (tg === 'TERMINATOR' || tg === 'INDENT' || tg === 'OUTDENT' ||
+              tg === '=' || tg === '->' || tg === '=>') break;
+        }
+        j--;
+      }
+      if (found < 0) return this.tagDoIife();
+      closeIdx = found;
+    }
 
-    let i = this.tokens.length - 1;
+    let i = closeIdx;
     let stack = [];
     this.tokens[i][0] = 'PARAM_END';
 
@@ -1540,7 +1573,7 @@ export class Lexer {
           tok[0] = 'PARAM_START';
           return this.tagDoIife(i - 1);
         } else {
-          this.tokens[this.tokens.length - 1][0] = 'CALL_END';
+          this.tokens[closeIdx][0] = 'CALL_END';
           return;
         }
       }

--- a/src/typecheck.js
+++ b/src/typecheck.js
@@ -629,6 +629,35 @@ export function createTypeCheckSettings(ts, overrides = {}) {
   };
 }
 
+// Collect ambient type packages (e.g. `@types/bun`, `@types/node`) by
+// walking up from rootPath gathering every `node_modules/@types` dir.
+// TS's default typeRoots only checks `<cwd>/node_modules/@types`, so a
+// sub-package check would miss workspace-root ambients. Accepts symlinks
+// because bun's nested-package layout symlinks `@types/bun` to
+// `.bun/@types+bun@.../node_modules/@types/bun`.
+export function collectAmbientTypes(rootPath) {
+  const typeRoots = [];
+  const types = [];
+  let dir = rootPath;
+  while (true) {
+    const cand = resolve(dir, 'node_modules/@types');
+    if (existsSync(cand)) {
+      typeRoots.push(cand);
+      try {
+        for (const entry of readdirSync(cand, { withFileTypes: true })) {
+          if ((entry.isDirectory() || entry.isSymbolicLink()) && !entry.name.startsWith('.') && !types.includes(entry.name)) {
+            types.push(entry.name);
+          }
+        }
+      } catch {}
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return { typeRoots, types };
+}
+
 // ── Param helpers ──────────────────────────────────────────────────
 
 // Extract the text between the first balanced ( ) — handles nested parens
@@ -826,7 +855,7 @@ function injectTypeParams(line, typeParams) {
 // source maps. Returns everything both the CLI and LSP need.
 // When opts.strict is true, all non-nocheck files are type-checked.
 export function compileForCheck(filePath, source, compiler, opts = {}) {
-  const result = compiler.compile(source, { sourceMap: true, types: 'emit', skipPreamble: true, stubComponents: true });
+  const result = compiler.compile(source, { sourceMap: true, types: 'emit', skipPreamble: true, stubComponents: true, inlineTypes: true });
   let code = result.code || '';
   const dts = result.dts ? result.dts.trimEnd() + '\n' : '';
 
@@ -1336,7 +1365,16 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
 
     for (let i = 0; i < dl.length; i++) {
       const m = dl[i].match(/^(?:export\s+)?declare\s+const\s+(\w+):\s+(.+);$/);
-      if (m) constTypes.set(m[1], { type: m[2], idx: i });
+      if (m) { constTypes.set(m[1], { type: m[2], idx: i }); continue; }
+      // Also merge `(export )?let X: T;` forward-decls from the DTS header
+      // into matching body `(export )?const X = expr` declarations. dts.js
+      // emits the `let` form for typed module-scope value bindings declared
+      // via `name:: T = expr`. Without this merge, TS sees two separate
+      // declarations (header `let` + body `const`) and loses the typed
+      // identity on property access — e.g. `getStore()` returns `unknown`
+      // instead of the declared `AsyncLocalStorage<T>`'s element type.
+      const lm = dl[i].match(/^(?:export\s+)?let\s+(\w+):\s+(.+);$/);
+      if (lm) constTypes.set(lm[1], { type: lm[2], idx: i });
     }
 
     if (constTypes.size > 0) {
@@ -1501,13 +1539,26 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
       const vars = m[2].split(/\s*,\s*/);
       const inlined = new Set();
       const bailed = new Set();
-      const scopeEndRe = new RegExp('^' + reEsc(baseIndent) + '}');
+      // Scope-end detection by indent: the enclosing block ends at the first
+      // non-empty line whose indent is strictly less than baseIndent. This is
+      // correct for compiler-generated JS where indentation reliably reflects
+      // nesting. Regex-matching `}` at baseIndent was wrong because inner
+      // block-closing braces (e.g. `  }` ending a nested `if`) sit at exactly
+      // baseIndent and would terminate the scan prematurely. For top-level
+      // hoists (baseIndent === ''), the scope is the whole file — never end.
+      const baseIndentLen = baseIndent.length;
+      const isScopeEnd = (line) => {
+        if (baseIndentLen === 0) return false;
+        if (line.trim() === '') return false;
+        const li = line.match(/^(\s*)/)[1].length;
+        return li < baseIndentLen;
+      };
 
       // Phase 1: straight-line scan at base indent
       for (let j = i + 1; j < cl.length; j++) {
         const line = cl[j];
         if (line.trim() === '') continue;
-        if (scopeEndRe.test(line)) break;
+        if (isScopeEnd(line)) break;
         // Skip deeper-indented lines
         if (line.startsWith(baseIndent + '  ')) continue;
         // Stop at structural statements (if/for/while/switch/try/do/function/class)
@@ -1539,7 +1590,7 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
         for (let j = i + 1; j < cl.length; j++) {
           const line = cl[j];
           if (line.trim() === '') continue;
-          if (scopeEndRe.test(line)) break;
+          if (isScopeEnd(line)) break;
           if (!vRe.test(line)) continue;
           if (firstRefLine < 0) firstRefLine = j;
           if (!foundAssign) {
@@ -1560,7 +1611,7 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
         for (let j = foundAssign.line + 1; j < cl.length; j++) {
           const line = cl[j];
           if (line.trim() === '') continue;
-          if (scopeEndRe.test(line)) { blockEndLine = j; break; }
+          if (isScopeEnd(line)) { blockEndLine = j; break; }
           const li = line.match(/^(\s*)/)[1];
           if (li.length < foundAssign.indent.length) { blockEndLine = j; break; }
         }
@@ -1571,7 +1622,7 @@ export function compileForCheck(filePath, source, compiler, opts = {}) {
           for (let j = blockEndLine + 1; j < cl.length; j++) {
             const line = cl[j];
             if (line.trim() === '') continue;
-            if (scopeEndRe.test(line)) break;
+            if (isScopeEnd(line)) break;
             if (vRe.test(line)) { hasRefAfterBlock = true; break; }
           }
         }
@@ -2658,6 +2709,56 @@ export async function runCheck(targetDir, opts = {}) {
     }
   }
 
+  // ── @rip-lang/* package resolution ─────────────────────────────────
+  //
+  // When a typed file imports from `@rip-lang/foo` (or `@rip-lang/foo/sub`),
+  // resolve the specifier via Node module resolution rooted at the project,
+  // and if it lands on a `.rip` entry, compile that entry with
+  // compileForCheck so its exported annotations become visible to TS as
+  // a virtual `.rip.ts` module. Diagnostics from the package itself are
+  // suppressed (`_typeOnly = true`) — package internals are checked when
+  // the package is checked, not when its consumers are.
+  const pkgRequire = createRequire(resolve(rootPath, 'package.json'));
+  const pkgSpecCache = new Map(); // spec → resolved abs path | null
+  function resolvePkgSpec(spec) {
+    if (pkgSpecCache.has(spec)) return pkgSpecCache.get(spec);
+    let resolved = null;
+    try {
+      const r = pkgRequire.resolve(spec);
+      if (typeof r === 'string' && r.endsWith('.rip') && existsSync(r)) resolved = r;
+    } catch {}
+    pkgSpecCache.set(spec, resolved);
+    return resolved;
+  }
+
+  const pkgSpecRe = /from\s+['"](@rip-lang\/[^'"]+)['"]/g;
+  const pendingPkgFiles = new Set();
+  for (const [, entry] of compiled) {
+    for (const m of entry.source.matchAll(pkgSpecRe)) {
+      const r = resolvePkgSpec(m[1]);
+      if (r && !compiled.has(r)) pendingPkgFiles.add(r);
+    }
+  }
+  // Iterate transitively: package files may themselves import other
+  // @rip-lang/* entries. Bounded by the number of unique resolved paths.
+  while (pendingPkgFiles.size) {
+    const next = pendingPkgFiles.values().next().value;
+    pendingPkgFiles.delete(next);
+    if (compiled.has(next)) continue;
+    try {
+      const pkgSrc = readFileSync(next, 'utf8');
+      const compiledPkg = compileForCheck(next, pkgSrc, new Compiler());
+      compiledPkg._typeOnly = true;
+      compiled.set(next, compiledPkg);
+      for (const m of pkgSrc.matchAll(pkgSpecRe)) {
+        const r = resolvePkgSpec(m[1]);
+        if (r && !compiled.has(r)) pendingPkgFiles.add(r);
+      }
+    } catch (e) {
+      console.warn(`[rip] @rip-lang package compile failed for ${next}: ${e.message}`);
+    }
+  }
+
   // Check for unresolved relative imports in all files (not just typed ones)
   const fileResults = [];
   let totalErrors = 0, totalWarnings = 0;
@@ -2689,7 +2790,17 @@ export async function runCheck(targetDir, opts = {}) {
   // contracts. The default is lenient to match Rip's "scaffolding, not
   // safety rails" philosophy; projects opt up when they want the
   // contract enforced.
-  const settings = createTypeCheckSettings(ts, strict ? { strict: true } : {});
+  // Collect `node_modules/@types` directories walking up from rootPath so
+  // ambient type packages (e.g. `@types/bun`) installed at the workspace
+  // root are picked up even when `rip check` runs in a sub-package. TS's
+  // default `typeRoots` only looks at `<cwd>/node_modules/@types`.
+  const { typeRoots, types: ambientTypes } = collectAmbientTypes(rootPath);
+
+  const settings = createTypeCheckSettings(ts, {
+    ...(strict ? { strict: true } : {}),
+    ...(typeRoots.length ? { typeRoots } : {}),
+    ...(ambientTypes.length ? { types: ambientTypes } : {}),
+  });
 
   const host = {
     getScriptFileNames: () => [...compiled.keys()].map(toVirtual),
@@ -2708,12 +2819,26 @@ export async function runCheck(targetDir, opts = {}) {
     getDirectories: (...a) => ts.sys.getDirectories(...a),
     directoryExists: (...a) => ts.sys.directoryExists(...a),
 
+    resolveTypeReferenceDirectives(typeDirectiveNames, containingFile, redirectedReference, options) {
+      return typeDirectiveNames.map((name) => {
+        const n = typeof name === 'string' ? name : name.name;
+        const r = ts.resolveTypeReferenceDirective(n, containingFile, options || settings, ts.sys, redirectedReference);
+        return r.resolvedTypeReferenceDirective;
+      });
+    },
+
     resolveModuleNames(names, containingFile) {
       return names.map((name) => {
         if (name.endsWith('.rip')) {
           const resolved = resolve(dirname(fromVirtual(containingFile)), name);
           if (compiled.has(resolved)) {
             return { resolvedFileName: toVirtual(resolved), extension: '.ts', isExternalLibraryImport: false };
+          }
+        }
+        if (name.startsWith('@rip-lang/')) {
+          const r = resolvePkgSpec(name);
+          if (r && compiled.has(r)) {
+            return { resolvedFileName: toVirtual(r), extension: '.ts', isExternalLibraryImport: false };
           }
         }
         const r = ts.resolveModuleName(name, containingFile, settings, {

--- a/src/types.js
+++ b/src/types.js
@@ -316,6 +316,7 @@ export function installTypeSupport(Lexer) {
 function collectTypeExpression(tokens, j) {
   let typeTokens = [];
   let depth = 0;
+  let bracketStack = []; // tracks innermost open bracket: '{', '[', '(', '<'
   let startJ = j;
 
   while (j < tokens.length) {
@@ -333,6 +334,8 @@ function collectTypeExpression(tokens, j) {
     // Handle >> as two > closes (nested generics: Map<string, Set<number>>)
     if (tTag === 'SHIFT' && t[1] === '>>' && depth >= 2) {
       depth -= 2;
+      if (bracketStack[bracketStack.length - 1] === '<') bracketStack.pop();
+      if (bracketStack[bracketStack.length - 1] === '<') bracketStack.pop();
       typeTokens.push(t);
       j++;
       continue;
@@ -340,6 +343,11 @@ function collectTypeExpression(tokens, j) {
 
     if (isOpen) {
       depth++;
+      let kind = (tTag === '{') ? '{'
+               : (tTag === '[' || tTag === 'INDEX_START') ? '['
+               : (tTag === 'COMPARE' && t[1] === '<') ? '<'
+               : '(';
+      bracketStack.push(kind);
       typeTokens.push(t);
       j++;
       continue;
@@ -347,6 +355,7 @@ function collectTypeExpression(tokens, j) {
     if (isClose) {
       if (depth > 0) {
         depth--;
+        bracketStack.pop();
         typeTokens.push(t);
         j++;
         continue;
@@ -374,6 +383,38 @@ function collectTypeExpression(tokens, j) {
           tTag === '->' || tTag === ',') {
         break;
       }
+    }
+
+    // Inside a bracketed type expression, INDENT/OUTDENT/TERMINATOR are
+    // pure layout tokens (multi-line type literal `{ \n field: T \n }`).
+    // They carry no semantic meaning and would otherwise leak their raw
+    // `[1]` value (e.g. an indent level integer like `2`) into the
+    // type string. INDENT/OUTDENT are dropped silently; TERMINATOR
+    // separates fields and is replaced with a synthetic `;` so the
+    // emitted type literal is valid TS (`{ a: T; b: U }`).
+    if (depth > 0 && (tTag === 'INDENT' || tTag === 'OUTDENT')) {
+      j++;
+      continue;
+    }
+    if (depth > 0 && tTag === 'TERMINATOR') {
+      typeTokens.push(['', ';']);
+      j++;
+      continue;
+    }
+
+    // Inside `{ ... }` the Rip rewriter sometimes drops TERMINATOR
+    // between fields (e.g. after `Record<string, string[]>` because `>`
+    // looks like a binary operator wanting a RHS). Detect a new field
+    // by seeing a PROPERTY token at the top of a `{` and inject `;` if
+    // the previously emitted token isn't already a separator/opener.
+    if (tTag === 'PROPERTY' &&
+        bracketStack[bracketStack.length - 1] === '{') {
+      let prev = typeTokens[typeTokens.length - 1];
+      let prevTag = prev?.[0];
+      let prevVal = prev?.[1];
+      let needsSep = prev && prevTag !== '{' && prevTag !== ',' &&
+                     !(prevTag === '' && prevVal === ';');
+      if (needsSep) typeTokens.push(['', ';']);
     }
 
     // => at depth 0: function type arrow, continue collecting

--- a/src/types.js
+++ b/src/types.js
@@ -392,6 +392,31 @@ function buildTypeString(typeTokens) {
   if (typeTokens.length === 0) return '';
   // Bare => (no params) means () => — add empty parens
   if (typeTokens[0]?.[0] === '=>') typeTokens.unshift(['', '()']);
+  // Validation: `::` inside `{ ... }` in type position is illegal.
+  // `::` binds a name to a type (params, var decls, return types).
+  // Inside a structural type literal `{ ... }`, fields are key→type
+  // pairs and use `:` (TS-style), the same way TS type literals do.
+  // `::` has no role inside a type literal — every `:` there is
+  // already unambiguously a type separator.
+  {
+    let curlyDepth = 0;
+    for (let t of typeTokens) {
+      let tag = t[0];
+      if (tag === '{') curlyDepth++;
+      else if (tag === '}') curlyDepth--;
+      else if (tag === 'TYPE_ANNOTATION' && curlyDepth > 0) {
+        let loc = t.loc;
+        let where = loc ? ` (line ${loc.r}, col ${loc.c})` : '';
+        let err = new Error(
+          `Use \`:\` (not \`::\`) inside a structural type literal${where}. ` +
+          `\`::\` binds a name to a type; inside \`{ ... }\` in type ` +
+          `position, fields use \`:\` (TS-style).`
+        );
+        err.loc = loc;
+        throw err;
+      }
+    }
+  }
   // Inline structural / function-param property-name optional marker:
   // an IDENTIFIER carrying `.data.optional` and followed by TYPE_ANNOTATION
   // gets a trailing `?` appended to its emitted name. The lexer stripped
@@ -399,8 +424,8 @@ function buildTypeString(typeTokens) {
   let parts = typeTokens.map((t, i) => {
     let next = typeTokens[i + 1];
     // Re-attach the trailing `?` for optional property names. The next
-    // separator may be `::` (TYPE_ANNOTATION) in function param lists or
-    // `:` inside an inline structural type literal like `{ x?: T }`.
+    // separator is `::` (TYPE_ANNOTATION) in function param lists, or
+    // `:` inside an inline structural type literal `{ x?: T }`.
     if (t.data?.optional && next && (next[0] === 'TYPE_ANNOTATION' || next[0] === ':')) {
       return `${t[1]}?`;
     }


### PR DESCRIPTION
Closes RFC 2 — [Rip packages exposing types to typed Rip apps](../blob/main/RFCS.md#rfc-2-rip-packages-exposing-types-to-typed-rip-apps).

RFC 2 is a **convention** decision: how should a Rip package expose types to typed Rip consumers? The RFC weighed three options — annotated source, sidecar \`.rip\` file, hand-written \`.d.ts\` — and picked **Option 1: annotated source**. The package's \`.rip\` source is its type contract; the existing \`compileForCheck\` pipeline strips annotations at runtime and emits a DTS for typed consumers on demand. One file, one source of truth, drift impossible by construction.

This PR lands that convention and proves it works end-to-end on a real, non-trivial package: \`@rip-lang/server\` (including \`@rip-lang/server/middleware\`).

## The convention, in one rule

> Every Rip package's \`.rip\` source IS its type contract. If a package wants to expose types, it annotates its exports. The Rip toolchain produces \`.d.ts\` from those annotations on demand. There is no separate types file, no module augmentation, and no hand-written TypeScript anywhere in the source tree.

## Compiler / type pipeline

- \`@types/bun\` is now picked up by \`rip check\`, so package source can lean on Bun's standard globals (\`Bun.Glob\`, \`Bun.file\`, etc.) without redeclaring them.
- Two parser gaps closed so real package source can be annotated without contortions:
  - Return-type annotations on arrow-assigned functions: \`handler = (c):: Response -> …\`.
  - Type annotations on rest params: \`(...args:: string[]) -> …\`.
- Lexer: \`collectTypeExpression\` now tracks a bracket stack alongside depth. Multi-line type literals (\`{ \\n field: T \\n }\`) drop INDENT/OUTDENT layout tokens and synthesize \`;\` between fields, so structured option types like

  \`\`\`coffee
  cors = (opts:: {
    origin?: string | string[]
    methods?: string | string[]
    credentials?: boolean
  } = {}) -> …
  \`\`\`

  emit valid TS without forcing the author onto one giant line.

## Server package — convention applied

- \`api.rip\`: \`read()\` and \`registerValidator()\` annotated. The package's primary validation surface now type-checks at every call site.
- \`middleware.rip\`: every exported middleware factory annotated with a structured option type that mirrors its existing doc-block header — \`cors\`, \`logger\`, \`compress\`, \`sessions\`, \`csrf\`, \`secureHeaders\`, \`timeout\`, \`bodyLimit\`, \`serve\`. Typed consumers get autocomplete and option-name typo detection at the \`use cors …\` / \`use serve …\` call site.

A few small refactors fell out of typing the surface honestly:

- \`serve._registered\` (ad-hoc property hung off the function) → module-level \`serveRegistered:: boolean\`. Typed signatures can't carry arbitrary properties, and this is a cleaner design — registration state was never really an attribute of the \`serve\` function.
- \`Array.from(glob.scanSync(...), String).sort()\` — uses the \`String\` constructor as the mapfn to narrow Bun's \`unknown[]\` iterator into \`string[]\` honestly at both layers: TS sees \`string[]\` because of \`String\`'s signature, and at runtime any non-string is coerced. Rip has no \`as\` cast on purpose; this pattern is what falls out of that choice, and it's better than a cast would be.
- \`b64urlToU8\`'s inner arrow callback gained a \`(c:: string)\` annotation.
- \`tests/csrf.rip\`: \`runCsrf\`'s \`mutate\` param now defaults to \`null\` (TS1016 — a required param can't follow an optional one, and \`headers = {}\` made the previous untyped \`mutate\` newly invalid once \`csrf\` itself became typed).

## VS Code extension

LSP updates so editor hover/completion/diagnostics reflect the new annotated package surface end-to-end.

## Validation

- \`rip check\` in \`packages/server\`: exit 0.
- \`rip check\` in \`examples/cart\`: exit 0.
- \`bun run test\`: 2142/2142 passing.

## What RFC 2 deliberately does *not* cover

Worth being explicit, because it's easy to read "typed server" as a bigger promise than the RFC actually makes:

- **Other Rip packages getting annotated** (\`@rip-lang/db\`, \`@rip-lang/ui\`, etc.) is **application** of this convention, not part of the convention itself. Each package will be its own follow-up.
- **Ambient framework globals** (\`createResource\`, \`launch\`, the stash helpers) live in the app framework, exposed via \`<script>\` tags rather than \`import\` — that's RFC 3, intentionally split off because the shape is different.
- **Synthesized \`this\` types** on handlers and components are RFCs 4 and 6.

This PR is the foundation those later RFCs build on.