### PR TITLE
db: harbor sessions no longer need a token — transaction docs

### DIFF
--- a/docs/RIP-DUCKDB.md
+++ b/docs/RIP-DUCKDB.md
@@ -495,13 +495,18 @@ gap in the `id` sequence. Gaps are normal and harmless; never write
 code that assumes ids are contiguous, and never predict "the next id"
 from the last one you saw.
 
-**Harbor sessions require an authenticated principal.** Transactions
-ride duckdb-harbor's session protocol (`POST /sessions`, then
-per-statement `session_id`), and harbor only creates *owned* sessions.
-An unauthenticated harbor (no token configured) can run plain queries
-but cannot open sessions — `schema.transaction!` will fail with a
-clear error. Set `RIP_DB_TOKEN` (or pass `token:` to
-`schema.connect`) for any deployment that uses transactions.
+**Harbor sessions work in every auth mode.** Transactions ride
+duckdb-harbor's session protocol (`POST /sql/sessions/new`, then
+per-statement `session_id`). Own-session lifecycle is scoped as
+`__HARBOR_SELF__:sessions:create` / `:delete` — allowed by default for
+any caller, including unauthenticated local-dev mode
+(`harbor_serve(..., token := NULL)`), where sessions are owned by the
+synthetic `harbor.local-dev` principal. A 403 from
+`schema.transaction!` means a custom `harbor_authorization_function`
+explicitly denies the `__HARBOR_SELF__:sessions:` scope — add a branch
+matching it. (Earlier harbor versions misfiled session creation as an
+admin action; that required `RIP_DB_TOKEN` plus an admin grant and is
+the reason older notes here said transactions need a token.)
 
 ---
 

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -95,10 +95,11 @@ same harbor instance automatically.
   it; returns a `TxHandle` `{ query(sql, params), commit(), rollback() }`.
   This is the transaction seam `schema.transaction!` uses — application
   code normally goes through the schema runtime rather than calling
-  `begin()` directly. Requires an authenticated harbor (set
-  `RIP_DB_TOKEN`): harbor only creates *owned* sessions, so an
-  unauthenticated deployment can run plain queries but not transactions.
-  `commit()`/`rollback()` always close the session, even on error.
+  `begin()` directly. Works in every harbor auth mode — sessions are
+  own-session scoped (`__HARBOR_SELF__:sessions:*`, allowed by default),
+  and unauthenticated local-dev harbor owns them via its synthetic
+  principal. `commit()`/`rollback()` always close the session, even on
+  error.
 - **`findOne(sql, params?)` / `findAll(sql, params?)`** — same, but rows come
   back as plain objects keyed by column name.
 - **`materializeAll(result)`** — turn a raw envelope into row objects.

--- a/packages/db/client.rip
+++ b/packages/db/client.rip
@@ -263,11 +263,12 @@ export query = (sql, params = [], opts = {}) ->
 #     tx.rollback!
 #     throw e
 #
-# NOTE: harbor gates session creation behind the authz policy string
-# `__HARBOR_ADMIN__:sessions:create`, which is default-deny when no
-# authz hook is configured. Transactions therefore require either a
-# harbor_authorization_function that allows it, or
-# `harbor_allow_admin_without_authz = true` on trusted deployments.
+# NOTE: harbor scopes own-session lifecycle as `__HARBOR_SELF__:
+# sessions:create` / `:delete` — allowed by default for any caller
+# (token-authenticated or unauthenticated local-dev mode), so
+# transactions work with zero authz configuration. A 403 here means a
+# custom harbor_authorization_function explicitly denies the
+# __HARBOR_SELF__:sessions: scope.
 export begin = (opts = {}) ->
   res = try
     fetch! "#{dbUrl()}/sql/sessions/new",
@@ -281,10 +282,10 @@ export begin = (opts = {}) ->
   if not res.ok or data?.ok is false or not data?.sessionId
     msg = data?.error or "harbor returned #{res.status} #{res.statusText or ''}".trim()
     if res.status is 403
-      msg = "transactions need a harbor DB session, and harbor denied session creation " +
-        "(authz policy __HARBOR_ADMIN__:sessions:create). Allow it in your " +
-        "harbor_authorization_function or set harbor_allow_admin_without_authz = true " +
-        "on a trusted deployment. Original error: #{msg}"
+      msg = "transactions need a harbor DB session, and harbor denied session creation. " +
+        "Sessions are allowed by default (authz scope __HARBOR_SELF__:sessions:create), " +
+        "so a 403 means your custom harbor_authorization_function denies that scope — " +
+        "add a branch matching '__HARBOR_SELF__:sessions:%'. Original error: #{msg}"
     throw new RipDBError msg,
       code:       data?.errorCode
       details:    data?.errorDetails


### PR DESCRIPTION
## Summary

Companion to duckdb-harbor's `session-authz` branch (`__HARBOR_SELF__` scope + local-dev sessions). Updates the three places that documented the old "transactions require `RIP_DB_TOKEN` + an admin grant" limitation:

- `packages/db/client.rip` — `begin()`'s comment and 403 error guidance now point at the one remaining cause (a custom authz policy denying `__HARBOR_SELF__:sessions:`), instead of recommending `harbor_allow_admin_without_authz`
- `docs/RIP-DUCKDB.md` §9 — "Harbor sessions work in every auth mode," with the history note explaining why older text said otherwise
- `packages/db/README.md` — `begin()` bullet updated to match

## Test plan
- [x] Live end-to-end: tokenless harbor (`token := NULL`, new build) + `schema.transaction!` — commit and rollback both verified
- [x] `rip check packages/db/` clean; core suite 2284 passing