### PR TITLE
schema: replace `#` unique sigil with `@unique` directive/attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Status = schema
 # DB-backed model
 User = schema :model
   name!   string
-  email!# email
+  email! email @unique
   @timestamps
   @has_many Order
   beforeValidation: -> @email = @email.toLowerCase()

--- a/docs/RIP-DUCKDB.md
+++ b/docs/RIP-DUCKDB.md
@@ -185,7 +185,7 @@ was originally documented from:
 ```coffee
 Partner = schema :model
   name!  string
-  slug!# string
+  slug! string @unique
 
 Patient = schema :model
   mrn?       string

--- a/docs/RIP-INTRO.md
+++ b/docs/RIP-INTRO.md
@@ -78,7 +78,7 @@ Read as families, not atoms:
 |---|---|---|
 | Existence / safety | `x?` · `x ?? y` · `a?.b` · `a?.[0]` · `a?.()` · `a?[0]` · `a?(x)` · `el?.prop = v` · `?!` (presence / Houdini) · `?? throw` | Nothing-safe access and guards |
 | Dammit / await | `fetch! url` · `user.save!` · `User.find! 1` | One glyph: "call it and await" |
-| Void / required | `def process!` (suppresses implicit return) · `name! string` (required field) · `email!#` (required + unique) | Same `!` glyph, context-disambiguated |
+| Void / required | `def process!` (suppresses implicit return) · `name! string` (required field) · `email! email @unique` (required + unique) | Same `!` glyph, context-disambiguated |
 | Math | `//` floor div · `%%` true mod · `1 < x < 10` chained compare · `arr[-1]` negative index · `"-" * 40` string repeat | Math you can read |
 | Regex | `str =~ /re/` with `_[1]` captures · `str[/re/, 1]` · `///...///` heregex | Pattern matching as an expression |
 | Assignment sugar | `.=` method-assign (`x .= trim()`) · `?.=` optional-chain assign · `*>obj = {a:1}` merge-assign | "Mutate this thing" |
@@ -188,7 +188,7 @@ Status = schema
 # DB-backed model
 User = schema :model
   name!   string
-  email!# email
+  email! email @unique
   role?   "admin" | "user"
   @timestamps
   @has_many Order
@@ -363,7 +363,7 @@ A close second is **non-reactive reads due to aliasing / stash access patterns**
 | `fetch!` | dammit — call + await |
 | `def fn!` | void — suppress implicit return |
 | `name! string` | required field (in `schema` body) |
-| `email!#` | required + unique (in `schema :model` body) |
+| `email! email @unique` | required + unique (in `schema :model` body) |
 | `MAX =! 100` | readonly const |
 
 ### The `?` family
@@ -383,7 +383,7 @@ A close second is **non-reactive reads due to aliasing / stash access patterns**
 | Line form | Example |
 |---|---|
 | Field (type implicit string) | `name! 1..50` |
-| Field + modifiers | `email!# email` (required + unique) |
+| Field + modifiers | `email! email @unique` (required + unique) |
 | Field + range | `password! 8..100` |
 | Field + literal union | `sex? "M" \| "F" \| "U"` |
 | Inline field transform | `email!, -> it.email.toLowerCase()` |

--- a/docs/RIP-LANG.md
+++ b/docs/RIP-LANG.md
@@ -1883,7 +1883,7 @@ Status = schema
 # DB-backed model with ORM and migrations
 User = schema :model
   name!   string
-  email!# email
+  email! email @unique
   @timestamps
   @has_many Order
   beforeValidation: -> @email = @email.toLowerCase()

--- a/docs/RIP-SCHEMA.md
+++ b/docs/RIP-SCHEMA.md
@@ -18,7 +18,7 @@ Rip Schema collapses all of them into one declaration:
 ```coffee
 User = schema :model
   name!   string, 1..100
-  email!# email
+  email! email @unique
   phone?  ~:phone
   @timestamps
   @has_many Order
@@ -268,7 +268,7 @@ Status.ok "unknown"      # false
 ```coffee
 User = schema :model
   name!    string, 1..100
-  email!#  email
+  email!   email @unique
   @timestamps
   @has_many Order
 
@@ -352,9 +352,9 @@ User = schema
 schema.defaultMaxString = 500
 
 Profile = schema :model
-  name!                         # → {min: 1, max: 500}
-  email!#     email             # → {max: 500}
-  bio?        text              # → uncapped (text opts out)
+  name!                  # → {min: 1, max: 500}
+  email! email @unique   # → {max: 500}
+  bio?   text            # → uncapped (text opts out)
 
 # One-line small shapes, plus a registered schema used as a field type.
 Address = schema :shape; street? ..200; city? ..100; zip? ..10
@@ -554,7 +554,7 @@ instances.
 ```coffee
 User = schema :model
   name!    string
-  email!#  email
+  email!   email @unique
   @timestamps
   @has_many Order
 
@@ -582,12 +582,15 @@ Modifiers:
 | Modifier | Meaning  |
 | -------- | -------- |
 | `!`      | required |
-| `#`      | unique (emits `UNIQUE` in DDL; also creates a unique index) |
 | `?`      | optional |
 
-Any combination works (`email!#` means required + unique). Order among
-modifiers doesn't matter. No modifier means "present but not required" —
+`!` and `?` are *shape* modifiers — they apply to every schema kind, and
+order doesn't matter. No modifier means "present but not required" —
 equivalent to `?` for validation purposes.
+
+Uniqueness is **not** a modifier — it's a *storage* constraint (only
+meaningful on `:model`), spelled `@unique`: inline as `email! email @unique`,
+or as a directive `@unique :email` (composite: `@unique [:partnerId, :mrn]`).
 
 **Type is optional** — when omitted, the field defaults to `string`. Type
 expressions accept:
@@ -605,7 +608,7 @@ expressions accept:
 Example = schema
   name!                                   # required string (default type)
   tags!      string[]                     # required array of strings
-  email!#    email                        # required, unique, email-format-validated
+  email!    email @unique                        # required, unique, email-format-validated
   bio?       text, 0..1000                # optional text, 0-1000 chars
   role?      string, ["user"]             # optional, default "user"
   status     string, [:draft]             # default :draft — same as ["draft"]
@@ -698,7 +701,7 @@ Imported = schema
   displayName! -> it.DisplayName
   shippedAt?   date, -> new Date(it.shippedAt)             # wire string → Date
   slug!        -> "#{it.FirstName}-#{it.LastName}".toLowerCase()
-  email!#      email, -> it.email.toLowerCase().trim()     # normalize + validate
+  email!       email @unique, -> it.email.toLowerCase().trim()     # normalize + validate
 ```
 
 Rules:
@@ -710,7 +713,7 @@ Rules:
   the line (type, range, regex, default, attrs). The comma is a
   structural boundary between the field declaration and the
   transform, not an argument separator — without it, lines like
-  `email!# email -> fn` misleadingly suggest `email` is an input to
+  `email! email -> fn` misleadingly suggest `email` is an input to
   the arrow. The bare form `name! -> fn` (nothing before the arrow
   except the name and modifiers) parses comma-less because there's
   nothing to elide. This is unlike Rip's general `get '/path' ->`
@@ -1726,10 +1729,12 @@ User.toSQL()
 # CREATE TABLE users (
 #   id INTEGER PRIMARY KEY DEFAULT nextval('users_seq'),
 #   name VARCHAR(100) NOT NULL,
-#   email VARCHAR NOT NULL UNIQUE,
+#   email VARCHAR NOT NULL,
 #   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 #   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 # );
+#
+# CREATE UNIQUE INDEX idx_users_email ON users ("email");
 #
 # CREATE UNIQUE INDEX idx_users_email ON users ("email");
 ```
@@ -1983,8 +1988,8 @@ Algebra operators derive new schemas from existing ones:
 
 ```coffee
 User = schema :model
-  name!    string
-  email!#  email, -> it.email.toLowerCase()
+  name!     string
+  email!    email @unique, -> it.email.toLowerCase()
   password! string
   full: ~> "#{@name} <#{@email}>"
   tagline: !> "#{@name} (active)"
@@ -2467,7 +2472,7 @@ for patient in patients
 ```coffee
 User = schema :model
   name!    string, 1..100
-  email!#  email
+  email!   email @unique
   @timestamps
   @has_many Order
 
@@ -2531,7 +2536,7 @@ Post = schema :model
 ```coffee
 User = schema :model
   name!     string
-  email!#   email
+  email!    email @unique
   password! string
   role?     string, [:user]
   @timestamps
@@ -2558,7 +2563,7 @@ declared, not guessed:
 # models.rip — week 2: rename a column, add a field, add a table
 User = schema :model
   fullName! string, 1..100, {was: "name"}   # rename annotation
-  email!#   email
+  email!    email @unique
   phone?    ~:phone                          # new column
   @timestamps
 
@@ -2805,7 +2810,8 @@ user-defined enums or shapes compose incrementally.
 | `@softDelete`                 | Adds `deleted_at` column; `.destroy()` sets `deleted_at = now()` instead of DELETE. Queries (`find`, `where`, `all`, `first`, `count`) implicitly filter `deleted_at IS NULL`; escape hatches: `.withDeleted()`, `.onlyDeleted()`, `inst.restore!`, `inst.destroy! hard: true` |
 | `@index [a, b, c]`            | Composite index on the listed columns                               |
 | `@index column`               | Single-column index (same as `@index [column]`)                     |
-| `@index [...] #`              | Unique index                                                        |
+| `@unique [a, b]`              | Composite unique constraint on the listed columns                   |
+| `@unique :column`             | Single-column unique (or inline on the field: `column! type @unique`) |
 | `@idStart N`                  | Seed value for the auto-id sequence in `.toSQL()` output (default `1`). Overridden per-call by `toSQL(idStart: N)`. |
 | `@scope :name, -> body`       | Named composable query scope — `this` is the builder; also `@scope :name, (args) -> body`. Installed on the model and the builder |
 | `@defaultScope -> body`       | Applied to every query unless `.unscoped()` is called. At most one per model |
@@ -2996,7 +3002,7 @@ schema.defaultMaxString = 500
 
 User = schema :model
   name!                         # → {min: 1, max: 500}  (sugar + pragma)
-  email!#    email              # → {max: 500}
+  email!     email @unique      # → {max: 500}
   code?                         # → {max: 500}
   password!  8..200             # → {min: 8, max: 200}  (explicit wins)
   bio?       text               # → no constraint       (text opts out)

--- a/examples/cart/api/models.rip
+++ b/examples/cart/api/models.rip
@@ -1,7 +1,7 @@
 export User = schema :model
   firstName! string, 1..
   lastName!  string, 1..
-  email!#    email
+  email!     email @unique
   phone?     string
   @timestamps
   @has_many Order

--- a/packages/vscode/syntaxes/schema.tmLanguage.json
+++ b/packages/vscode/syntaxes/schema.tmLanguage.json
@@ -15,7 +15,7 @@
   "repository": {
 
     "comments": {
-      "comment": "Only match # when preceded by whitespace or at start of line, not after word chars (email!#)",
+      "comment": "Match # only at start of line or after whitespace (standard Rip comment); never mid-token",
       "name": "comment.line.number-sign.rip-schema",
       "match": "(?:^|(?<=\\s))#.*$"
     },
@@ -39,8 +39,8 @@
           }
         },
         {
-          "comment": "Index directive with fields",
-          "match": "(@index)\\b",
+          "comment": "Index / unique constraint directives with fields",
+          "match": "(@(?:index|unique))\\b",
           "name": "keyword.other.directive.rip-schema"
         },
         {
@@ -54,8 +54,8 @@
     "fields": {
       "patterns": [
         {
-          "comment": "Field with modifiers and type: name!# string, [1, 100]",
-          "match": "^(\\s+)([a-z]\\w*)((?:[!#?])+)?\\s+([a-z]\\w*|[A-Z]\\w*)",
+          "comment": "Field with modifiers and type: name! string, [1, 100]",
+          "match": "^(\\s+)([a-z]\\w*)((?:[!?])+)?\\s+([a-z]\\w*|[A-Z]\\w*)",
           "captures": {
             "2": { "name": "variable.other.field.rip-schema" },
             "3": { "name": "keyword.operator.modifier.rip-schema" },

--- a/src/schema/runtime-ddl.js
+++ b/src/schema/runtime-ddl.js
@@ -133,11 +133,11 @@ __SchemaDef.prototype._tableSpec = function (options) {
     indexes.push({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
   }
   for (const d of norm.directives) {
-    if (d.name !== 'index') continue;
+    if (d.name !== 'index' && d.name !== 'unique') continue;
     const ixArgs = d.args?.[0] || {};
     const cols = (ixArgs.fields || []).map(__schemaSnake);
     if (!cols.length) continue;
-    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: ixArgs.unique === true });
+    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
   }
 
   return {
@@ -159,7 +159,13 @@ function __schemaRenderColumn(spec, col, fkByColumn) {
     parts[0] = '  ' + col.name + ' ' + col.type + ' PRIMARY KEY';
   } else {
     if (col.notNull) parts.push('NOT NULL');
-    if (col.unique) parts.push('UNIQUE');
+    // Uniqueness is emitted as a single named index (`idx_<table>_<col>`),
+    // never as an inline column `UNIQUE`. Inline UNIQUE created a second,
+    // auto-named index the migrate differ's fold (__schemaFoldSpec) can't
+    // normalize; the named index is what ADD COLUMN and introspection
+    // already round-trip through. `col.unique` stays the canonical spec
+    // flag — it drives the index below and the differ — it just no longer
+    // renders here.
   }
   const fk = fkByColumn ? fkByColumn.get(col.name) : null;
   if (fk) parts.push('REFERENCES ' + fk.refTable + '(' + fk.refColumn + ')');

--- a/src/schema/runtime-ddl.js
+++ b/src/schema/runtime-ddl.js
@@ -126,18 +126,34 @@ __SchemaDef.prototype._tableSpec = function (options) {
     columns.push({ name: 'deleted_at', type: 'TIMESTAMP', notNull: false, unique: false, default: null, was: null });
   }
 
+  // Index names are derived from their column set (`idx_<table>_<cols>`),
+  // so two declarations on the same columns collide. That's always a
+  // redundant/contradictory schema (a `@unique` index already serves as an
+  // index for those columns) — reject it loudly rather than emit duplicate
+  // CREATE INDEX statements.
   const indexes = [];
+  const indexByName = new Map();
+  const addIndex = (ix) => {
+    if (indexByName.has(ix.name)) {
+      throw new Error(
+        `Table '${table}': duplicate index '${ix.name}' on (${ix.columns.join(', ')}). ` +
+        `Those columns are declared unique/indexed more than once — a '@unique' already ` +
+        `creates an index, so remove the redundant '@unique'/'@index' declaration.`);
+    }
+    indexByName.set(ix.name, ix);
+    indexes.push(ix);
+  };
   for (const [n, f] of norm.fields) {
     if (!f.unique) continue;
     const col = __schemaSnake(n);
-    indexes.push({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
+    addIndex({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
   }
   for (const d of norm.directives) {
     if (d.name !== 'index' && d.name !== 'unique') continue;
     const ixArgs = d.args?.[0] || {};
     const cols = (ixArgs.fields || []).map(__schemaSnake);
     if (!cols.length) continue;
-    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
+    addIndex({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
   }
 
   return {

--- a/src/schema/runtime-validate.js
+++ b/src/schema/runtime-validate.js
@@ -436,7 +436,7 @@ class __SchemaDef {
           fields.set(e.name, {
             name: e.name,
             required: e.modifiers.includes('!'),
-            unique: e.modifiers.includes('#'),
+            unique: e.unique === true,
             optional: e.modifiers.includes('?'),
             typeName: e.typeName,
             literals: e.literals || null,
@@ -1641,10 +1641,10 @@ function __schemaDerive(source, transform) {
   for (const [, f] of derivedFields) {
     const mods = [];
     if (f.required) mods.push('!');
-    if (f.unique) mods.push('#');
     if (f.optional && !f.required) mods.push('?');
     entries.push({
       tag: 'field', name: f.name, modifiers: mods,
+      unique: f.unique === true,
       typeName: f.typeName, array: f.array,
       literals: f.literals || null,
       coerce: f.coerce === true,
@@ -1716,7 +1716,7 @@ function __schemaExpandMixins(host, fields, directives, ctx) {
       fields.set(e.name, {
         name: e.name,
         required: e.modifiers.includes('!'),
-        unique: e.modifiers.includes('#'),
+        unique: e.unique === true,
         optional: e.modifiers.includes('?'),
         typeName: e.typeName,
         literals: e.literals || null,

--- a/src/schema/runtime.generated.js
+++ b/src/schema/runtime.generated.js
@@ -3052,18 +3052,34 @@ __SchemaDef.prototype._tableSpec = function (options) {
     columns.push({ name: 'deleted_at', type: 'TIMESTAMP', notNull: false, unique: false, default: null, was: null });
   }
 
+  // Index names are derived from their column set (\`idx_<table>_<cols>\`),
+  // so two declarations on the same columns collide. That's always a
+  // redundant/contradictory schema (a \`@unique\` index already serves as an
+  // index for those columns) — reject it loudly rather than emit duplicate
+  // CREATE INDEX statements.
   const indexes = [];
+  const indexByName = new Map();
+  const addIndex = (ix) => {
+    if (indexByName.has(ix.name)) {
+      throw new Error(
+        \`Table '\${table}': duplicate index '\${ix.name}' on (\${ix.columns.join(', ')}). \` +
+        \`Those columns are declared unique/indexed more than once — a '@unique' already \` +
+        \`creates an index, so remove the redundant '@unique'/'@index' declaration.\`);
+    }
+    indexByName.set(ix.name, ix);
+    indexes.push(ix);
+  };
   for (const [n, f] of norm.fields) {
     if (!f.unique) continue;
     const col = __schemaSnake(n);
-    indexes.push({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
+    addIndex({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
   }
   for (const d of norm.directives) {
     if (d.name !== 'index' && d.name !== 'unique') continue;
     const ixArgs = d.args?.[0] || {};
     const cols = (ixArgs.fields || []).map(__schemaSnake);
     if (!cols.length) continue;
-    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
+    addIndex({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
   }
 
   return {

--- a/src/schema/runtime.generated.js
+++ b/src/schema/runtime.generated.js
@@ -524,7 +524,7 @@ class __SchemaDef {
           fields.set(e.name, {
             name: e.name,
             required: e.modifiers.includes('!'),
-            unique: e.modifiers.includes('#'),
+            unique: e.unique === true,
             optional: e.modifiers.includes('?'),
             typeName: e.typeName,
             literals: e.literals || null,
@@ -1729,10 +1729,10 @@ function __schemaDerive(source, transform) {
   for (const [, f] of derivedFields) {
     const mods = [];
     if (f.required) mods.push('!');
-    if (f.unique) mods.push('#');
     if (f.optional && !f.required) mods.push('?');
     entries.push({
       tag: 'field', name: f.name, modifiers: mods,
+      unique: f.unique === true,
       typeName: f.typeName, array: f.array,
       literals: f.literals || null,
       coerce: f.coerce === true,
@@ -1804,7 +1804,7 @@ function __schemaExpandMixins(host, fields, directives, ctx) {
       fields.set(e.name, {
         name: e.name,
         required: e.modifiers.includes('!'),
-        unique: e.modifiers.includes('#'),
+        unique: e.unique === true,
         optional: e.modifiers.includes('?'),
         typeName: e.typeName,
         literals: e.literals || null,
@@ -3059,11 +3059,11 @@ __SchemaDef.prototype._tableSpec = function (options) {
     indexes.push({ name: 'idx_' + table + '_' + col, columns: [col], unique: true });
   }
   for (const d of norm.directives) {
-    if (d.name !== 'index') continue;
+    if (d.name !== 'index' && d.name !== 'unique') continue;
     const ixArgs = d.args?.[0] || {};
     const cols = (ixArgs.fields || []).map(__schemaSnake);
     if (!cols.length) continue;
-    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: ixArgs.unique === true });
+    indexes.push({ name: 'idx_' + table + '_' + cols.join('_'), columns: cols, unique: d.name === 'unique' });
   }
 
   return {
@@ -3085,7 +3085,13 @@ function __schemaRenderColumn(spec, col, fkByColumn) {
     parts[0] = '  ' + col.name + ' ' + col.type + ' PRIMARY KEY';
   } else {
     if (col.notNull) parts.push('NOT NULL');
-    if (col.unique) parts.push('UNIQUE');
+    // Uniqueness is emitted as a single named index (\`idx_<table>_<col>\`),
+    // never as an inline column \`UNIQUE\`. Inline UNIQUE created a second,
+    // auto-named index the migrate differ's fold (__schemaFoldSpec) can't
+    // normalize; the named index is what ADD COLUMN and introspection
+    // already round-trip through. \`col.unique\` stays the canonical spec
+    // flag — it drives the index below and the differ — it just no longer
+    // renders here.
   }
   const fk = fkByColumn ? fkByColumn.get(col.name) : null;
   if (fk) parts.push('REFERENCES ' + fk.refTable + '(' + fk.refColumn + ')');

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -740,17 +740,27 @@ function parseFieldedLine(kind, line, entries, ctx) {
   let modifiers = collectModifiers(first);
   let pos = 1;
 
-  // Adjacent `!`, `#`, `?` modifier tokens. `!` and `?` are absorbed into
-  // the IDENTIFIER's data by the main lexer. `#` arrives as a standalone
-  // token because the schema commentToken exception kicks in when `#` is
-  // adjacent to an identifier. A modifier must be unspaced from the
-  // token it follows, so we check the preceding token's `.spaced` flag
+  // Adjacent `!`, `?` modifier tokens. They are absorbed into the
+  // IDENTIFIER's data by the main lexer. A modifier must be unspaced from
+  // the token it follows, so we check the preceding token's `.spaced` flag
   // (which the whitespace pass sets to true when whitespace follows).
+  //
+  // `#` used to be a third (unique) modifier; it arrives as a standalone
+  // token because the schema commentToken exception kicks in when `#` is
+  // adjacent to an identifier. Uniqueness is now a storage concern spelled
+  // `@unique` — so a leftover `#` here is a removed-syntax migration error,
+  // not a silent no-op.
   while (pos < line.length) {
     let tk = line[pos];
     let adjacent = line[pos - 1] && !line[pos - 1].spaced;
     if (!adjacent) break;
-    if (tk[0] === '#' || tk[0] === '?' || tk[0] === '!') {
+    if (tk[0] === '#') {
+      throw schemaError(tk,
+        `The '#' unique modifier was removed. Mark uniqueness with '@unique': ` +
+        `inline as '${name}! <type> @unique', or as a directive '@unique :${name}' ` +
+        `(composite: '@unique [:a, :b]').`);
+    }
+    if (tk[0] === '?' || tk[0] === '!') {
       modifiers.push(tk[0]);
       pos++;
       continue;
@@ -864,7 +874,7 @@ function parseFieldedLine(kind, line, entries, ctx) {
   // Comma-required rule: if a type was consumed and the next token is
   // `->` (no comma separator), reject with a clear diagnostic. The
   // comma is a structural boundary between the field declaration and
-  // the transform; skipping it makes `email!# email -> fn` read as
+  // the transform; skipping it makes `email! email -> fn` read as
   // if 'email' were an argument to the arrow, which it isn't.
   let typeConsumed = typeFirst?.[0] === 'IDENTIFIER' || typeFirst?.[0] === 'STRING';
   if (typeConsumed && rest[0]?.[0] === '->') {
@@ -876,6 +886,7 @@ function parseFieldedLine(kind, line, entries, ctx) {
   let rangeTokens = null;
   let regexToken = null;
   let transformTokens = null;
+  let uniqueAttr = false;
 
   if (rest.length > 0) {
     // The leading comma is only required when a type was consumed. If
@@ -970,9 +981,26 @@ function parseFieldedLine(kind, line, entries, ctx) {
             `Transform '-> …' must be the last element on the field line for '${name}'.`);
         }
         transformTokens = part.slice(1);
+      } else if (head[0] === '@') {
+        // Trailing `@unique` — single-column uniqueness co-located on the
+        // field (mirrors Prisma's field-level `@unique`). Uniqueness is a
+        // storage property, so it rides as a field attribute, not a `!`/`?`
+        // shape modifier. Composite uniqueness uses the `@unique [...]`
+        // directive on its own line.
+        let attrTok = part[1];
+        let attrName = attrTok && (attrTok[0] === 'IDENTIFIER' || attrTok[0] === 'PROPERTY') ? attrTok[1] : null;
+        if (part.length === 2 && attrName === 'unique') {
+          if (uniqueAttr) {
+            throw schemaError(head, `Field '${name}' has more than one '@unique'.`);
+          }
+          uniqueAttr = true;
+        } else {
+          throw schemaError(head,
+            `Unknown inline attribute '@${attrName ?? ''}' on field '${name}'. The only inline attribute is '@unique'.`);
+        }
       } else {
         throw schemaError(head,
-          `Unexpected trailer for field '${name}'. Expected '[…]' default, '{…}' attrs, '/regex/', 'min..max' range, or '-> transform'.`);
+          `Unexpected trailer for field '${name}'. Expected '[…]' default, '{…}' attrs, '/regex/', 'min..max' range, '-> transform', or '@unique'.`);
       }
     }
   }
@@ -1008,6 +1036,7 @@ function parseFieldedLine(kind, line, entries, ctx) {
     tag: 'field',
     name,
     modifiers,
+    unique: uniqueAttr,
     typeName,
     array,
     literals,
@@ -1910,6 +1939,7 @@ function entryLiteral(emitter, e) {
         `typeName: ${JSON.stringify(e.typeName)}`,
         `array: ${e.array ? 'true' : 'false'}`,
       ];
+      if (e.unique) obj.push('unique: true');
       if (e.literals) {
         obj.push(`literals: ${JSON.stringify(e.literals)}`);
       }
@@ -2316,6 +2346,37 @@ function serializeLiteral(v) {
   return JSON.stringify(v);
 }
 
+// Extract a column-name list from a directive's args — a single name
+// (`field` / `:field`) or a bracketed list (`[:a, :b]`). Accepts bare
+// identifiers and `:symbol` form interchangeably; both denote field names.
+// Shared by `@unique` and `@index`.
+function collectDirectiveFieldNames(tokens) {
+  let isName = (t) => t && (t[0] === 'IDENTIFIER' || t[0] === 'PROPERTY' || t[0] === 'SYMBOL');
+  let fields = [];
+  let pos = 0;
+  if (isName(tokens[pos])) {
+    fields.push(tokens[pos][1]);
+  } else if (tokens[pos]?.[0] === '[' || tokens[pos]?.[0] === 'INDEX_START') {
+    let inner = [];
+    let depth = 1;
+    pos++;
+    while (pos < tokens.length && depth > 0) {
+      let t = tokens[pos];
+      if (t[0] === '[' || t[0] === 'INDEX_START') depth++;
+      if (t[0] === ']' || t[0] === 'INDEX_END') {
+        depth--;
+        if (depth === 0) { pos++; break; }
+      }
+      inner.push(t);
+      pos++;
+    }
+    for (let part of splitTopLevelByComma(inner)) {
+      if (isName(part[0])) fields.push(part[0][1]);
+    }
+  }
+  return fields;
+}
+
 // Compile directive args to a JS literal list or null. Each directive has
 // its own arg shape — we centralize the parsing here so Layer 2 can rely
 // on normalized structures.
@@ -2348,38 +2409,24 @@ function compileDirectiveArgsLiteral(name, tokens) {
     return `[{${parts.join(', ')}}]`;
   }
 
-  // `@index field` or `@index [a, b]` or `@index [a, b] #` for unique.
-  if (name === 'index') {
-    let fields = [];
-    let unique = false;
-    let pos = 0;
-    if (tokens[pos]?.[0] === 'IDENTIFIER' || tokens[pos]?.[0] === 'PROPERTY') {
-      fields.push(tokens[pos][1]);
-      pos++;
-    } else if (tokens[pos]?.[0] === '[' || tokens[pos]?.[0] === 'INDEX_START') {
-      let inner = [];
-      let depth = 1;
-      pos++;
-      while (pos < tokens.length && depth > 0) {
-        let t = tokens[pos];
-        if (t[0] === '[' || t[0] === 'INDEX_START') depth++;
-        if (t[0] === ']' || t[0] === 'INDEX_END') {
-          depth--;
-          if (depth === 0) { pos++; break; }
-        }
-        inner.push(t);
-        pos++;
-      }
-      for (let part of splitTopLevelByComma(inner)) {
-        if (part[0] && (part[0][0] === 'IDENTIFIER' || part[0][0] === 'PROPERTY')) {
-          fields.push(part[0][1]);
-        }
-      }
+  // `@unique :field`, `@unique field`, or `@unique [:a, :b]` — a unique
+  // constraint (model-only). Single-field uniqueness is more commonly
+  // written inline as `field! type @unique`; this directive form covers
+  // composite keys and the single-field case when you prefer it separate.
+  if (name === 'unique') {
+    let fields = collectDirectiveFieldNames(tokens);
+    if (!fields.length) {
+      throw schemaError(tokens[0] || tokens[tokens.length - 1],
+        `@unique requires a field name or list — '@unique :email' or '@unique [:a, :b]'.`);
     }
-    if (tokens[pos]?.[0] === '#') unique = true;
-    let parts = [`fields: ${JSON.stringify(fields)}`];
-    if (unique) parts.push('unique: true');
-    return `[{${parts.join(', ')}}]`;
+    return `[{fields: ${JSON.stringify(fields)}}]`;
+  }
+
+  // `@index field` or `@index [a, b]` — a non-unique index. Uniqueness is
+  // spelled `@unique`, never `@index … #` (the `#` unique flag was removed).
+  if (name === 'index') {
+    let fields = collectDirectiveFieldNames(tokens);
+    return `[{fields: ${JSON.stringify(fields)}}]`;
   }
 
   // `@on :field` — the :union discriminator. Pre-validated by

--- a/test/rip/schema.rip
+++ b/test/rip/schema.rip
@@ -4538,6 +4538,21 @@ fail "removed: '#' unique modifier is rejected", '''
     email!# email
   '''
 
+# Two index declarations on the same columns collide on index name — a
+# redundant/contradictory schema, rejected loudly rather than emitting
+# duplicate CREATE INDEX.
+test "duplicate index on the same columns is rejected", modelHeader + '''
+  User = schema :model
+    email! email @unique
+    @index :email
+  err = null
+  try
+    User._tableSpec()
+  catch e
+    err = e
+  [err?.message.includes("duplicate index"), err?.message.includes("idx_users_email")]
+''', [true, true]
+
 test "diff: empty database plans CREATE for every model", migrateHeader + '''
   User = schema :model
     name! string

--- a/test/rip/schema.rip
+++ b/test/rip/schema.rip
@@ -94,13 +94,13 @@ code "mixin with fields only", '''
 code "model with modifiers and directives", '''
   User = schema :model
     name!    string
-    email!#  email
+    email!   email @unique
     bio?     text
     @timestamps
     @belongs_to Organization
   ''', '''
   let User;
-  User = __schema({kind: "model", name: "User", entries: [{tag: "field", name: "name", modifiers: ["!"], typeName: "string", array: false}, {tag: "field", name: "email", modifiers: ["!","#"], typeName: "email", array: false}, {tag: "field", name: "bio", modifiers: ["?"], typeName: "text", array: false}, {tag: "directive", name: "timestamps"}, {tag: "directive", name: "belongs_to", args: [{target: "Organization"}]}]});
+  User = __schema({kind: "model", name: "User", entries: [{tag: "field", name: "name", modifiers: ["!"], typeName: "string", array: false}, {tag: "field", name: "email", modifiers: ["!"], typeName: "email", array: false, unique: true}, {tag: "field", name: "bio", modifiers: ["?"], typeName: "text", array: false}, {tag: "directive", name: "timestamps"}, {tag: "directive", name: "belongs_to", args: [{target: "Organization"}]}]});
   ''', opts
 
 code "model recognizes known hook names", '''
@@ -606,7 +606,7 @@ test "default-string: constraint immediately after modifier", '''
 
 test "default-string: required+unique without explicit type", '''
   U = schema :shape
-    code!#
+    code! @unique
   U.ok({code: "abc"})
   ''', true
 
@@ -848,12 +848,12 @@ code "bare modifier (no ! no ?) has no implicit min", '''
   X = __schema({kind: "shape", name: "X", entries: [{tag: "field", name: "name", modifiers: [], typeName: "string", array: false, constraints: {max: 20}}]});
   ''', opts
 
-code "!# (required+unique) + ..N implies min=1", '''
+code "required @unique + ..N implies min=1", '''
   X = schema
-    token!# ..60
+    token! ..60, @unique
   ''', '''
   let X;
-  X = __schema({kind: "input", name: "X", entries: [{tag: "field", name: "token", modifiers: ["!","#"], typeName: "string", array: false, constraints: {min: 1, max: 60}}]});
+  X = __schema({kind: "input", name: "X", entries: [{tag: "field", name: "token", modifiers: ["!"], typeName: "string", array: false, unique: true, constraints: {min: 1, max: 60}}]});
   ''', opts
 
 code "! + N..N (explicit min) does not override", '''
@@ -1025,8 +1025,8 @@ test "transform: thrown error surfaces as issue", '''
 
 test "transform: survives algebra (.pick preserves transform)", '''
   User = schema :shape
-    email!# email, -> it.email.toLowerCase()
-    name!# -> it.Name
+    email! email, -> it.email.toLowerCase()
+    name! -> it.Name
   Slim = User.pick("email", "name")
   out = Slim.parse({email: "ALICE@X.com", Name: "Alice"})
   [out.email, out.name]
@@ -1051,7 +1051,7 @@ test "transform: comma-less bare form (no type, no constraints)", '''
 
 test "transform: comma required after type", '''
   X = schema
-    email!# email, -> it.email.toLowerCase()
+    email! email, -> it.email.toLowerCase()
   X.parse({email: "HELLO@X.COM"}).email
   ''', "hello@x.com"
 
@@ -1063,7 +1063,7 @@ test "transform: comma required after range", '''
 
 fail "transform: missing comma after type is rejected", '''
   X = schema
-    email!# email -> it.email.toLowerCase()
+    email! email -> it.email.toLowerCase()
   '''
 
 fail "transform: missing comma after range is rejected", '''
@@ -2156,7 +2156,7 @@ modelHeader = '''
 test ":model toSQL emits CREATE TABLE", modelHeader + '''
   User = schema :model
     name! string, 1..100
-    email!# email
+    email! email @unique
     @timestamps
   sql = User.toSQL()
   [sql.includes("CREATE TABLE users"), sql.includes("VARCHAR(100)"), sql.includes("UNIQUE"), sql.includes("created_at"), sql.includes("updated_at")]
@@ -3277,7 +3277,7 @@ test "multi-line trailers split on commas (range + regex across lines)", '''
 
 test "multi-line trailer ending in a transform still parses", '''
   X = schema
-    email!# email,
+    email! email,
       ..320,
       -> it.email.toLowerCase()
   v = X.parse {email: "A@B.CO"}
@@ -3624,7 +3624,7 @@ test "UNIQUE violation surfaces as SchemaError {field, error: 'unique'}", '''
   __SchemaRegistry.reset()
   User = schema :model
     name! string
-    email!# email
+    email! email @unique
   err = null
   try
     User.create! {name: "A", email: "a@b.c"}
@@ -3777,7 +3777,7 @@ test ".upsert! emits ON CONFLICT DO UPDATE; branch hooks skipped", modelHeader +
   trace = []
   User = schema :model
     name! string
-    email!# email
+    email! email @unique
     beforeSave:   -> trace.push "beforeSave"
     beforeCreate: -> trace.push "beforeCreate"
     beforeUpdate: -> trace.push "beforeUpdate"
@@ -4490,7 +4490,7 @@ test "_tableSpec exposes the canonical table structure", modelHeader + '''
     name! string
   User = schema :model
     name!   string, 1..100
-    email!# email
+    email!  email @unique
     @timestamps
     @softDelete
     @belongs_to Org
@@ -4507,6 +4507,36 @@ test "_tableSpec exposes the canonical table structure", modelHeader + '''
     spec.indexes.map (i) -> i.name + (i.unique ? "!" : "")
   ]
 ''', ["users", "users_seq:1", ["id", "name", "email", "org_id", "created_at", "updated_at", "deleted_at"], "VARCHAR(100)", true, "orgs", ["idx_users_email!", "idx_users_name_email"]]
+
+# Regression: the `@unique` DIRECTIVE forms (the silent-no-op bug that
+# motivated retiring `#`). `@unique :col` and `@unique [a, b]` must each
+# emit a UNIQUE index — single and composite.
+test "@unique directive: single + composite emit unique indexes", modelHeader + '''
+  User = schema :model
+    a!     string
+    b!     string
+    email! email
+    @unique :email
+    @unique [:a, :b]
+  User._tableSpec().indexes.map (i) -> i.name + (i.unique ? "!" : "")
+''', ["idx_users_email!", "idx_users_a_b!"]
+
+# `@unique` rides through mixin expansion like any other field attribute.
+test "@unique survives mixin expansion", modelHeader + '''
+  Keyed = schema :mixin
+    code! string @unique
+  Thing = schema :model
+    @mixin Keyed
+    name! string
+  Thing._tableSpec().indexes.map (i) -> i.name + (i.unique ? "!" : "")
+''', ["idx_things_code!"]
+
+# Clean break: the removed `#` unique modifier is a hard compile error,
+# not a silent no-op.
+fail "removed: '#' unique modifier is rejected", '''
+  User = schema :model
+    email!# email
+  '''
 
 test "diff: empty database plans CREATE for every model", migrateHeader + '''
   User = schema :model
@@ -4528,7 +4558,7 @@ test "diff: empty database plans CREATE for every model", migrateHeader + '''
 test "diff: matching database plans nothing (round-trip clean)", migrateHeader + '''
   User = schema :model
     name!   string, 1..100
-    email!# email
+    email!  email @unique
     @timestamps
   deployed.tables = [{
     name: "users"
@@ -4555,7 +4585,7 @@ test "diff: added columns classify by shape (optional / default / required / uni
     bio?   text
     plan?  string, ["free"]
     code!  string
-    tag!#  string
+    tag!   string @unique
   deployed.tables = [{
     name: "users", sequence: {name: "users_seq", start: 1}, primaryKey: "id"
     columns: [

--- a/test/schema/extract.test.js
+++ b/test/schema/extract.test.js
@@ -36,7 +36,7 @@ function assert(cond, msg) { if (!cond) throw new Error(msg || 'assertion failed
 const MODELS = `export User = schema :model
   firstName! string, 1..
   lastName!  string
-  email!#    email
+  email!     email @unique
   phone?     string
   @timestamps
 


### PR DESCRIPTION
## What & why

Retires the `#` unique sigil in schema field declarations in favor of `@unique`.

`#` was a poor fit:
- **Collides with the comment character** — needs a whitespace-sensitive lexer carve-out to tell `email!#` from `email! #comment`.
- **No "unique" mnemonic.**
- **Mis-categorized** — `!`/`?` are *shape* modifiers (apply to every schema kind); uniqueness is a *storage* constraint, only meaningful on `:model`.

It also had a **silent failure**: `@unique [...]` *looked* like a real directive but was never implemented, so composite unique constraints were silently dropped (confirmed against a live DB — the directive produced zero indexes).

## New syntax

Uniqueness is now `@unique`, in two positions — inline on the field, or as a directive:

```
email! email @unique        # single, co-located on the field
@unique :email              # single, as a directive
@unique [:partnerId, :mrn]  # composite
```

**Clean break:** `#` as a unique flag is removed everywhere (field modifier *and* `@index … #`); hitting it raises a migration error pointing at `@unique`. `@index` stays for non-unique indexes (and now also accepts `:symbol` field names, for consistency).

## Double-index fix (bundled)

A `#` field previously emitted **both** an inline column `UNIQUE` (→ an auto-named index the migrate differ's `__schemaFoldSpec` can't normalize) **and** an explicit `idx_<table>_<col>`. Uniqueness now renders as **exactly one named index**. `col.unique` remains the canonical in-spec flag — it drives the index and the differ — it just no longer renders inline. The named index is the representation `ADD COLUMN` and introspection already round-trip through, so this also removes a latent stray-index diff.

## Duplicate-index guard

Index names derive from their column set (`idx_<table>_<cols>`), so two declarations on the same columns (e.g. a field `@unique` plus an `@index`/`@unique` directive on that column) would have collided into duplicate `CREATE INDEX` statements. `_tableSpec` now rejects this loudly — a `@unique` index already serves as an index for those columns, so the second declaration is always redundant.

## Migrated in this PR

- `examples/cart`
- schema + doc test fixtures
- `docs/RIP-SCHEMA.md` (modifier table, directives table, rendered-SQL example) + INTRO/README/LANG/DUCKDB
- VS Code schema grammar (`@unique` highlighting; `#` dropped from the modifier class)

## Tests

- New regressions: `@unique` directive forms (single + composite → unique indexes), `@unique` survives mixin expansion, `#` is rejected with a migration error, and duplicate index declarations are rejected.
- Green: schema suite (437), full unit (2299), schema-package checks (72), doctest (0 failed), runtime-fresh check.