### PR TITLE
compiler: escape backticks in interpolated strings (fix broken template-literal emit)

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3269,17 +3269,28 @@ export class CodeEmitter {
     return `${tagCode}\`${content}\``;
   }
 
+  // Escape literal text for safe inclusion in a JS template literal: a raw
+  // backtick would close the literal early, and a literal `${` would be read as
+  // an interpolation. (Rip interpolation is `#{}`, so `${` in source is literal.)
+  escapeTemplateText(s) {
+    return s.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
+  }
+
   emitString(head, rest) {
     let result = '`';
     for (let part of rest) {
       if (part instanceof String) {
-        result += this.extractStringContent(part);
+        // Literal segment of an interpolated string — must be escaped, exactly
+        // as the non-interpolated heredoc path does. Without this, a literal
+        // backtick or `${` in an interpolated string emitted broken JS (the
+        // backtick terminated the template literal early).
+        result += this.escapeTemplateText(this.extractStringContent(part));
       } else if (typeof part === 'string') {
         if (part.startsWith('"') || part.startsWith("'")) {
           if (this.options.debug) console.warn('[Rip] Unexpected quoted primitive in str:', part);
-          result += part.slice(1, -1);
+          result += this.escapeTemplateText(part.slice(1, -1));
         } else {
-          result += part;
+          result += this.escapeTemplateText(part);
         }
       } else if (Array.isArray(part)) {
         if (part.length === 1 && typeof part[0] === 'string' && !Array.isArray(part[0])) {

--- a/test/rip/strings.rip
+++ b/test/rip/strings.rip
@@ -534,6 +534,13 @@ test 'if/then/else in interpolation plural', 'n = 3; "#{n} item#{if n is 1 then 
 test 'ternary in interpolation', 'n = 1; "#{n} item#{n is 1 ? "" : "s"}"', '1 item'
 test 'postfix if in interpolation', 'n = 3; "#{n} item#{"" if n is 1 else "s"}"', '3 items'
 
+# Literal backtick in an interpolated string must be escaped in the emitted
+# template literal — regression: a raw backtick closed the template early,
+# breaking compilation of the surrounding code.
+test 'literal backtick in interpolated string', 'x = 1; "a `b` #{x}"', 'a `b` 1'
+test 'literal backtick in interpolated heredoc', '''x = 2
+"""tick `t` #{x}"""''', 'tick `t` 2'
+
 # Quote preservation - single quotes
 code 'single quote preserved', "'hello'", "'hello'"
 


### PR DESCRIPTION
## Summary

Fixes a real compiler bug: an **interpolated** string/heredoc compiles to a JS *template literal*, but `emitString` appended its literal segments **verbatim** — so a literal **backtick** in the source emitted a raw backtick into the template, **closing it early** and producing broken JS. The non-interpolated heredoc path already escaped backticks (`content.replace(/\`/g, '\\\`')`); the interpolation path didn't.

### Repro
```
v = "V"
x = """// gen #{v}
// see `foo`"""
```
Before: emits `` `// gen ${v}\n// see `foo`` `` — the raw backtick terminates the template literal → the surrounding code fails to compile.
After: emits `` `// gen ${v}\n// see \`foo\`` `` ✓

(Surfaced while writing generated-code comments containing backticks inside an interpolated `"""..."""` heredoc in `solar.rip`.)

## Fix
`emitString` now routes every literal segment through `escapeTemplateText` (backtick → `` \` ``, and `${` → `\${` — the latter a defensive no-op since Rip parses `${}` as interpolation too, so a literal `${` never reaches a segment). Mirrors what the non-interpolated path already did.

## Tests
- `test/rip/strings.rip`: literal backtick in an interpolated string and in an interpolated heredoc both round-trip to the correct runtime value.
- Full `bun run test:all` green.