### PR TITLE
compiler: fix misleading escapeTemplateText comment + test both interpolation forms

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -3269,9 +3269,13 @@ export class CodeEmitter {
     return `${tagCode}\`${content}\``;
   }
 
-  // Escape literal text for safe inclusion in a JS template literal: a raw
-  // backtick would close the literal early, and a literal `${` would be read as
-  // an interpolation. (Rip interpolation is `#{}`, so `${` in source is literal.)
+  // Escape literal text for safe inclusion in the emitted JS template literal:
+  // a raw backtick would close the literal early, and a literal `${` would be
+  // read by JS as an interpolation. This is about the JS *output*, not Rip
+  // syntax — Rip interpolates BOTH `#{...}` and `${...}`, and both are already
+  // split into separate interpolation parts before we get here, so a literal
+  // segment shouldn't actually contain `${`; the escape is a defensive guard
+  // that keeps the helper correct for any literal text.
   escapeTemplateText(s) {
     return s.replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
   }

--- a/test/rip/strings.rip
+++ b/test/rip/strings.rip
@@ -538,6 +538,9 @@ test 'postfix if in interpolation', 'n = 3; "#{n} item#{"" if n is 1 else "s"}"'
 # template literal — regression: a raw backtick closed the template early,
 # breaking compilation of the surrounding code.
 test 'literal backtick in interpolated string', 'x = 1; "a `b` #{x}"', 'a `b` 1'
+# Both interpolation forms must coexist with a literal backtick.
+test 'literal backtick with ${} interpolation', 'x = 1; "a `b` ${x}"', 'a `b` 1'
+test 'literal backtick with both #{} and ${}', 'x = 1; y = 2; "`#{x}` and `${y}`"', '`1` and `2`'
 test 'literal backtick in interpolated heredoc', '''x = 2
 """tick `t` #{x}"""''', 'tick `t` 2'
 


### PR DESCRIPTION
## Summary

Follow-up to #34. The `escapeTemplateText` **comment was wrong** — it claimed Rip interpolation is only `#{}` (so `${` is "literal"). In fact **Rip interpolates both `#{...}` and `${...}`**.

The **code is correct** and unchanged: both interpolation forms are split into separate interpolation *parts* and emitted via the array-part path, never through `escapeTemplateText` (which only touches the *literal* text between interpolations). The `${` escape is about the emitted **JS** template literal (where a literal `${` would be JS interpolation), not Rip source — and since Rip parses `${` as interpolation, a literal segment shouldn't contain it at all, making the escape a defensive guard.

## Changes
- Corrected the comment to explain it accurately (JS-output framing; both Rip interpolation forms noted).
- Added regression tests pinning that a literal backtick coexists with `${}` interpolation and with both `#{}`/`${}` in one string — e.g. `` "`#{x}` and `${y}`" `` → `` `1` and `2` ``.

No behavior change; full suite green (2341).