### PR TITLE
fix(server): exclude package test/demo files from the serve() browser bundle

### DIFF
--- a/packages/server/middleware.rip
+++ b/packages/server/middleware.rip
@@ -175,6 +175,15 @@ resolvePackageDir = (appDir, pkgKey) ->
   catch
     null
 
+# A package-relative path that must never ship in the browser bundle: test
+# and example sources. Matched on the package-relative path (forward-slash
+# separators, as produced by Bun.Glob) so legitimate files whose names merely
+# contain "test" (e.g. `latest.rip`, `mytest/x.rip`) are kept.
+export isBundleExcludedPath = (path: string): boolean ->
+  /(?:^|\/)tests?\//.test(path) or
+  /(?:^|\/)(?:test|demo)\.rip$/.test(path) or
+  /\.(?:test|spec)\.rip$/.test(path)
+
 # Classify a package as browser-shippable or server-only based on its
 # `rip.browser` opt-in field. Returns:
 #   { kind: 'browser', dir, entry }  — bundle .rip files under _lib/<short>/
@@ -1092,6 +1101,9 @@ export serve = (opts: {
           unless pkgPaths.length > 0
             raise "Package '#{pkgKey}' has no .rip source files at #{classified.dir}."
           for path in pkgPaths
+            # Skip test/example sources — they never belong in a browser bundle,
+            # and shared component names (e.g. `Test`) collide across packages.
+            continue if isBundleExcludedPath(path)
             src = readFileSync("#{classified.dir}/#{path}", 'utf8')
             if NODE_BUILTIN_RE.test(src)
               raise "Package '#{pkgKey}' file '#{path}' imports a Node built-in module and cannot be shipped to the browser."

--- a/packages/server/tests/bundle_exclude.rip
+++ b/packages/server/tests/bundle_exclude.rip
@@ -1,0 +1,34 @@
+import { test, ok } from './runner.rip'
+import { isBundleExcludedPath } from '../middleware.rip'
+
+# serve()'s package-dependency crawl inlines every `**/*.rip` under a
+# browser-safe @rip-lang/* package into the bundle. Test/example sources must
+# be skipped: they don't belong in a browser bundle, and several packages ship
+# a `test.rip` that compiles to a component named `Test` → collision warning.
+
+test "excludes files under a test/ directory", ->
+  ok isBundleExcludedPath('test/test.rip')
+  ok isBundleExcludedPath('test/helpers.rip')
+  ok isBundleExcludedPath('browser/test/widget.rip')
+
+test "excludes files under a tests/ directory", ->
+  ok isBundleExcludedPath('tests/foo.rip')
+  ok isBundleExcludedPath('src/tests/foo.rip')
+
+test "excludes root test.rip / demo.rip", ->
+  ok isBundleExcludedPath('test.rip')
+  ok isBundleExcludedPath('demo.rip')
+  ok isBundleExcludedPath('examples/demo.rip')
+
+test "excludes *.test.rip and *.spec.rip", ->
+  ok isBundleExcludedPath('foo.test.rip')
+  ok isBundleExcludedPath('foo.spec.rip')
+  ok isBundleExcludedPath('a/b/widget.test.rip')
+
+test "keeps legitimate sources whose names merely contain 'test'", ->
+  ok not isBundleExcludedPath('index.rip')
+  ok not isBundleExcludedPath('latest.rip')
+  ok not isBundleExcludedPath('contest.rip')
+  ok not isBundleExcludedPath('mytest/widget.rip')
+  ok not isBundleExcludedPath('browser/components/badge.rip')
+  ok not isBundleExcludedPath('attestation.rip')


### PR DESCRIPTION
## Root cause

`serve()`'s package-dependency crawl (`packages/server/middleware.rip`, the `for path in pkgPaths` loop) inlines **every** `**/*.rip` under each browser-safe `@rip-lang/*` dependency into the `_pkg/<short>/` bundle prefix, with no test filter. So any package that ships test/example sources leaks them into the browser bundle:

- `@rip-lang/time` → `test/test.rip`, `demo.rip`
- `@rip-lang/validate` → `test.rip`
- `@rip-lang/csv` → `test/test.rip`, `test/bench.rip`

Worse, multiple of these compile to a component named `Test`, so the app loader emits a **`Component name collision: Test`** warning (`packages/app/index.rip` ~L1831). `classified.entry` is computed but never constrains which files ship.

## Fix

Add a small, surgical `isBundleExcludedPath(path)` predicate and a `continue if` guard in the crawl loop, matched on the **package-relative** path so legitimate files whose names merely contain "test" are kept (`latest.rip`, `mytest/x.rip`, `attestation.rip`). It excludes:

- anything under a `test/` or `tests/` directory
- `test.rip`, `*.test.rip`, `*.spec.rip`, `demo.rip`

This resolves the `Component name collision: Test` warning and keeps test code out of every app's browser bundle. Server-side only (`middleware.rip` isn't in `rip.min.js`), so no browser-bundle rebuild is needed.

## Test plan

- `bun run test:all` — GREEN (295 + validate 44, 0 failed).
- `packages/server` suite — GREEN (396 passing), incl. new `tests/bundle_exclude.rip` covering the predicate (test dirs, `test.rip`/`demo.rip`, `*.test.rip`/`*.spec.rip`, and the keep-cases).
- Deterministic crawl check against real packages: only genuine test/demo files dropped — `time` drops `demo.rip`+`test/test.rip` (keeps `time.rip`), `validate` drops `test.rip` (keeps `validate.rip`), `csv` drops `test/*` (keeps `csv.rip`), `http` drops nothing, `ui` keeps all 70 files.
- UI gallery (`packages/ui/index.rip`) still boots and bundles: `/` and `/app` both 200, `/app` bundle byte-identical to `main` (54 modules, valid JSON, 0 test-like modules).